### PR TITLE
Copy edit pages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
     webrick (1.7.0)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-19
   x86_64-linux

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
     webrick (1.7.0)
 
 PLATFORMS
+  arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-19

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This repository documents common tooling we use in our Python projects in the [A
 It is designed as a static GitHub pages site.
 
 ## Contributing
-The website and source pages are publicly available, but contributions are restricted to members and associate members of ARC.
+The [website](https://ucl-arc.github.io/python-tooling/) and source pages are publicly available, but contributions are restricted to members and associate members of ARC.
 
 Pages all live in the `pages` sub-directory, and are written in markdown.
 

--- a/index.md
+++ b/index.md
@@ -8,11 +8,15 @@ This site documents common tooling we use in Python projects at the [Advanced Re
 
 It is not comprehensive, but intended as a forum to share knowledge across projects.
 Each page contains a table of packages or services that are useful when building a Python package.
-Each entry has a link to the package or service, a short summary of what it does, traffic lights and used by if available.
+Each entry has
+- a link to the package or service
+- a short summary of what it does
+- traffic lights
+- a link to a package developed by someone in ARC that uses it
 
 ## Choosing tools
 If you are working within a larger community, always start with the same tools they recommend.
-For example, the [`napari`](https://napari.org/) community have the  [`cookiecutter-napari-plugin`](https://github.com/napari/cookiecutter-napari-plugin) for setting up a new package, and the [SciKit-Surgery](https://scikit-surgery.github.io/scikit-surgery/) libraries have the [Cookiecutter-PythonTemplate](https://github.com/SciKit-Surgery/PythonTemplate) to create new python-based libraries.
+For example, the [`napari`](https://napari.org/) community have [`cookiecutter-napari-plugin`](https://github.com/napari/cookiecutter-napari-plugin) and the [SciKit-Surgery](https://scikit-surgery.github.io/scikit-surgery/) community have [PythonTemplate](https://github.com/SciKit-Surgery/PythonTemplate), both used to create new Python-based libraries.
 This makes it easier for others in the community to contribute to your package, and once you get used to the structure makes it easier for you to contribute back to other packages.
 
 Otherwise, each page on this site highlights recommended packages or services for each area.
@@ -22,4 +26,4 @@ These should not be taken as set in stone for every project, but are a good plac
 Each item has an (opinionated) traffic light. The meaning of these is:
 - 🟢 At least one person in ARC uses this. We actively recommend using it above other tools. It is the single recommended package for a given purpose.
 - 🟠 We don't discourage using this, but it may duplicate functionality of a green tool.
-- 🔴 We actively discourage using this. This could be because it's no longer maintained, not open source, or difficult to use. Consider moving to alternatives if you're currently using something that's red. A reason is given next to each red item.
+- 🔴 We actively discourage using this. This could be because it's no longer maintained, not open source, or difficult to use. Consider moving to alternatives if you're currently using something that's red. A reason for not using this is given.

--- a/pages/benchmarking.md
+++ b/pages/benchmarking.md
@@ -6,7 +6,7 @@ layout: default
 # Benchmarking
 
 | Name     | Short description | 🚦 |
-| -------- | ------------------| -- |
+| -------- | ------------------| :--: |
 | [pyinstrument](https://pyinstrument.readthedocs.io/en/stable) | Python profiler. Tells you how long individual lines of code take to run, so you can focus on the slowest part of your program to speed it up. | 🟢 |
 | [snakeviz](https://jiffyclub.github.io/snakeviz/) | Browser based graphical viewer for the output of Python’s cProfile module. | 🟢 |
 | [asv](https://asv.readthedocs.io/en/stable/) | A tool for benchmarking Python packages over their lifetime. Allows you to write benchmarks and then run them against every commit in the repository, to identify where performance increased or decreased. | 🟢 |

--- a/pages/bindings.md
+++ b/pages/bindings.md
@@ -1,0 +1,14 @@
+---
+title: Bindings
+layout: default
+---
+
+# Bindings
+
+| Name     | Short description | 🚦 |
+| -------- | ------------------| :--: |
+| [Cython](https://cython.readthedocs.io/en/latest/src/userguide/wrapping_CPlusPlus.html) | C/C++ binding library with numpy array integration | 🟢 |
+| [ctypes](https://docs.python.org/3.8/library/ctypes.html) | Native python method for calling functions in shared C libraries | 🟠 |
+| [pybind11](https://github.com/pybind/pybind11) | Bindings to C++ with a steep learning curve | 🟠 |
+| [f2py](https://numpy.org/devdocs/f2py/f2py.getting-started.html) | Bindings to Fortran developed by numpy | 🟠 |
+| [pyO3](https://github.com/PyO3/pyo3) | Straightforward bindings to rust with support for [packaging](https://github.com/PyO3/maturin) | 🟢 |

--- a/pages/ci.md
+++ b/pages/ci.md
@@ -6,16 +6,16 @@ layout: default
 # Continuous integration
 
 | Name     | Short description | 🚦 |
-| -------- | ------------------| -- |
-| [GitHub Actions](https://docs.github.com/en/actions) | Continuous integration and continuous delivery (CI/CD) platform (integrated with GitHub) | 🟢 |
-| [Travis CI](https://docs.travis-ci.com/) | Continuous integration and continuous delivery (CI/CD) platform | 🟠 |
-| [AppVeyor](https://www.appveyor.com/docs/) | Continuous integration and continuous delivery (CI/CD) platform | 🟠 |
-| [Bamboo](https://confluence.atlassian.com/bamboo/bamboo-documentation-289276551.html) | Atlassian continuous integration and continuous delivery (CI/CD) platform | 🟠 |
+| -------- | ------------------| :--: |
+| [GitHub Actions](https://docs.github.com/en/actions) | Continuous integration and continuous delivery platform (integrated with GitHub). | 🟢 |
+| [Travis CI](https://docs.travis-ci.com/) | Continuous integration and continuous delivery platform. | 🟠 |
+| [AppVeyor](https://www.appveyor.com/docs/) | Continuous integration and continuous delivery platform. | 🟠 |
+| [Bamboo](https://confluence.atlassian.com/bamboo/bamboo-documentation-289276551.html) | Atlassian continuous integration and continuous delivery platform. | 🟠 |
 
 
 # Coverage monitoring
 
 | Name     | Short description | 🚦 |
-| -------- | ------------------| -- |
-| [Codecov](https://docs.codecov.com/docs) | Hosted service to report code coverage metrics | 🟢 |
-| [Coveralls](https://docs.coveralls.io/) | Hosted service to report code coverage metrics | 🟠 |
+| -------- | ------------------| :--: |
+| [Codecov](https://docs.codecov.com/docs) | Hosted service to report code coverage metrics. | 🟢 |
+| [Coveralls](https://docs.coveralls.io/) | Hosted service to report code coverage metrics. | 🟠 |

--- a/pages/community.md
+++ b/pages/community.md
@@ -6,13 +6,12 @@ layout: default
 # Community building
 There are many platforms to build a community for users and developers.
 We recommend you choose one, and not more than one.
-If you are creating a new space, you might like to consider to join an existing community space.
-Common topics in such communities can be developers meetings, ideas for new directions, and general help and support to people.
+If you are creating a new space, you should consider joining an existing community space.
+Common topics discussed in these communities can be developers meetings, ideas for new directions, and general help and support for users.
 
-| Name                                                  | Short description                                                                                                        | 🚦 | Used by                                                                        |
-|-------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------| ---- |--------------------------------------------------------------------------------|
-| [Discussions](https://docs.github.com/en/discussions) | collaborative communication forum for the community around an open source or internal project.                | 🟠 | [SciKit-Surgery](https://github.com/SciKit-Surgery/scikit-surgery/discussions) |
-| [Slack](https://slack.com/intl/en-gb/)                | Instant message program for professional and organizational communications. Free option and pro for £5.75 per person/month | 🟠 |  |
-| [Discourse](https://discourse.org/)                   | Instant message program for professional and organizational communications. From $25 per month.                          | 🟠 | [napari](https://forum.image.sc/tag/napari) |
-| [Gitter](https://gitter.im/)                      | Open-source instant messaging and chat room system for developers and users of GitLab and GitHub repositories            | 🟠 |  |
-
+| Name  | Short description  | 🚦 | Used by  |
+|-------|--------------------|:---:|---------|
+| [Discussions](https://docs.github.com/en/discussions) | Discussion forum built into GitHub repositories. | 🟠 | [SciKit-Surgery](https://github.com/SciKit-Surgery/scikit-surgery/discussions) |
+| [Slack](https://slack.com/intl/en-gb/) | Instant messaging platform. | 🟠 |  |
+| [Discourse](https://discourse.org/) | Discussion forum.  | 🟠 | [napari](https://forum.image.sc/tag/napari) |
+| [Gitter](https://gitter.im/) | Open-source instant messaging platform. Links directly to GitLab or GitHub repositories. | 🟠 | [Matplotlib](https://gitter.im/matplotlib/matplotlib) |

--- a/pages/dev.md
+++ b/pages/dev.md
@@ -24,4 +24,4 @@ layout: default
 | [jedi](https://jedi.readthedocs.io/en/latest/) | Refactoring and autocompletion used in IDEs. | |
 | [rope](https://rope.readthedocs.io/en/latest/overview.html) | Refactoring library. |  |
 | [tqdm](https://pypi.org/project/tqdm/2.2.3/) | Progress bar for loops. |  |
-| [psutil](https://psutil.readthedocs.io/en/latest/) | system monitoring, profiling, limiting process resources and the management of running processes. |  |
+| [psutil](https://psutil.readthedocs.io/en/latest/) | System monitoring, profiling, limiting process resources and the management of running processes. |  |

--- a/pages/dev.md
+++ b/pages/dev.md
@@ -5,23 +5,23 @@ layout: default
 
 # Integrated Development Environments (IDEs)
 
-| Name     | Short description | 🚥 |
-| -------- | ------------------| ---------------|
-| [Visual Studio Code](https://code.visualstudio.com/docs) | A light-weight general-purpose IDE | 🟠 |
-| [PyCharm](https://www.jetbrains.com/pycharm/) | A Python IDE by JetBrains | 🟠 |
+| Name     | Short description | 🚦 |
+| -------- | ------------------| :--: |
+| [Visual Studio Code](https://code.visualstudio.com/docs) | A light-weight general-purpose IDE. | 🟠 |
+| [PyCharm](https://www.jetbrains.com/pycharm/) | A Python IDE by JetBrains. | 🟠 |
 
 # Virtual environments
 
-| Name     | Short description | 🚥 |
-| -------- | ------------------| ---------------|
-| [pipenv](https://pipenv.pypa.io/en/latest/) | A tool that automatically creates and manages a virtualenv for your projects | 🟠 |
-| [virtualenv](https://virtualenv.pypa.io/en/latest/) | A tool to create isolated Python environments | 🟠 |
+| Name     | Short description | 🚦 |
+| -------- | ------------------| :--: |
+| [pipenv](https://pipenv.pypa.io/en/latest/) | A tool that automatically creates and manages a virtualenv for your projects. | 🟠 |
+| [virtualenv](https://virtualenv.pypa.io/en/latest/) | A tool to create isolated Python environments. | 🟠 |
 
 # Other
 
-| Name     | Short description | 🚥 |
-| -------- | ------------------| ---------------|
-| [jedi](https://jedi.readthedocs.io/en/latest/) | Refactoring and autocompletion used in IDEs| |
-| [rope](https://rope.readthedocs.io/en/latest/overview.html) | Refactoring library | - |
-| [tqdm](https://pypi.org/project/tqdm/2.2.3/) | Progress bar for loops | - |
-| [psutil](https://psutil.readthedocs.io/en/latest/) | system monitoring, profiling, limiting process resources and the management of running processes | - |
+| Name     | Short description | 🚦 |
+| -------- | ------------------| :--: |
+| [jedi](https://jedi.readthedocs.io/en/latest/) | Refactoring and autocompletion used in IDEs. | |
+| [rope](https://rope.readthedocs.io/en/latest/overview.html) | Refactoring library. |  |
+| [tqdm](https://pypi.org/project/tqdm/2.2.3/) | Progress bar for loops. |  |
+| [psutil](https://psutil.readthedocs.io/en/latest/) | system monitoring, profiling, limiting process resources and the management of running processes. |  |

--- a/pages/docs.md
+++ b/pages/docs.md
@@ -5,11 +5,23 @@ layout: default
 
 # Documentation
 
+## Doc building
+
 |  Name     | Short description | 🚦 | Used by |
-| -------- | ------------------| ---- | ----- |
+| -------- | ------------------| :--: | ----- |
 | [sphinx](https://www.sphinx-doc.org/en/master/) | Generates documentation from reStructuredText or Markdown files | 🟢 | [TLOModel](https://github.com/UCL/TLOmodel) |
-| [sphinx-gallery](https://sphinx-gallery.github.io/stable/index.html) | Builds an HTML gallery of examples from a set of Python scripts | 🟢 | [svGFPA](https://github.com/joacorapela/svGPFA) |
 | [mkdocs](https://www.mkdocs.org/) | Generates documentation from Markdown files | 🟠 |  |
 | [pdoc](https://pdoc.dev/) | Auto-generates API documentation from docstrings | 🟠 | [MICI](https://github.com/matt-graham/mici) |
 | [gitbook](https://www.gitbook.com/) | General documentation builder; integrates with GitHub | 🟠 |  |
+
+## Sphinx extensions
+
+|  Name     | Short description | 🚦 | Used by |
+| -------- | ------------------| :--: | ----- |
+| [sphinx-gallery](https://sphinx-gallery.github.io/stable/index.html) | Builds an HTML gallery of examples from a set of Python scripts | 🟢 | [svGFPA](https://github.com/joacorapela/svGPFA) |
+
+## Other
+
+|  Name     | Short description | 🚦 | Used by |
+| -------- | ------------------| :--: | ----- |
 | [binder](https://mybinder.org/) | Turns a Git repository into a collection of interactive notebooks | 🟢 | [LiPyphilic](https://github.com/p-j-smith/lipyphilic) |

--- a/pages/linting.md
+++ b/pages/linting.md
@@ -7,18 +7,20 @@ layout: default
 
 See [here for example configuration](https://github.com/paddyroddy/python-template) for some of these.
 
+## Code formatting
+
 | Name     | Short description | 🚦 |
-| -------- | ------------------| - |
-| [autopep8](https://github.com/hhatto/autopep8) | formatter which conforms to PEP 8 | 🟠 |
-| [black](https://black.readthedocs.io/en/stable/) | opinionated formatter, defaults to 88 characters per line | 🟢 |
-| [flake8](https://flake8.pycqa.org/en/latest/) | linter which complains if code doesn't follow a rule. Does not support modern `pyproject.toml` configuration. | 🔴 |
-| [isort](https://pycqa.github.io/isort/) | sorts imports alphabetically, splits into first/third party, works on python & cython code | 🟢 |
-| [mypy](https://mypy.readthedocs.io/en/stable/) | static type checker, won't fail if no typing but will if typing is incorrect | 🟢 |
-| [pre-commit](https://pre-commit.com/) | universal tool which performs a git hook on commit, allows you to run linters/formatters on any code | 🟢 |
-| [pycodestyle](https://pycodestyle.pycqa.org/en/latest/) | linter which checks for errors | 🟠 |
-| [pyflakes](https://github.com/PyCQA/pyflakes) | linter which checks for errors | 🟠 |
-| [pylint](https://pylint.readthedocs.io/en/latest/) | linter which checks for errors | 🟠 |
-| [ruff](https://github.com/charliermarsh/ruff) | a very fast linter which incorporates other linters | 🟢 |
-| [sourcery](https://sourcery.ai/) | an AI code reviewer which simplifies code, has a free version but can pay for fancier features | 🟠 |
-| [toml-sort](https://toml-sort.readthedocs.io/en/latest/) | sorts TOML files which are now part of PEP 8 | 🟢 |
-| [yapf](https://github.com/google/yapf) | Google formatter | 🟠 |
+| -------- | ------------------| :-: |
+| [black](https://black.readthedocs.io/en/stable/) | Opinionated formatter, defaults to 88 characters per line. | 🟢 |
+| [autopep8](https://github.com/hhatto/autopep8) | Formatter which conforms to PEP 8. | 🟠 |
+| [isort](https://pycqa.github.io/isort/) | Sorts imports alphabetically, splits into first/third party, works on python & cython code. | 🟢 |
+| [mypy](https://mypy.readthedocs.io/en/stable/) | Static type checker, won't fail if no typing but will if typing is incorrect. | 🟢 |
+| [pre-commit](https://pre-commit.com/) | Universal tool which performs a git hook on commit, allows you to run linters/formatters on any code. | 🟢 |
+| [pycodestyle](https://pycodestyle.pycqa.org/en/latest/) | Linter which checks for errors. | 🟠 |
+| [pyflakes](https://github.com/PyCQA/pyflakes) | Linter which checks for errors. | 🟠 |
+| [pylint](https://pylint.readthedocs.io/en/latest/) | Linter which checks for errors. | 🟠 |
+| [ruff](https://github.com/charliermarsh/ruff) | A very fast linter which incorporates other linters. | 🟠 |
+| [sourcery](https://sourcery.ai/) | An AI code reviewer which simplifies code, has a free version but can pay for fancier features. | 🟠 |
+| [toml-sort](https://toml-sort.readthedocs.io/en/latest/) | Sorts TOML files which are now part of PEP 8. | 🟢 |
+| [yapf](https://github.com/google/yapf) | Google formatter. | 🟠 |
+| [flake8](https://flake8.pycqa.org/en/latest/) | Linter which complains if code doesn't follow a rule. Does not support modern `pyproject.toml` configuration. | 🔴 |

--- a/pages/packaging.md
+++ b/pages/packaging.md
@@ -6,10 +6,9 @@ layout: default
 # Packaging
 
 | Name | Short description | Used by | 🚦 |
-| ---- | ----------------- | ------- | --- |
-| [build](https://pypa-build.readthedocs.io/en/stable/) | Straightforward tool to build the distribution package. Does not perform dependency management. | | 🟢 |
-| [setuptools](https://setuptools.pypa.io)   | Packaging, distribution, installation. "Makes your code installable". | [autodE](https://github.com/duartegroup/autodE), [hdr_disease_prevalence](https://github.com/UCL-ARC/hdr_disease_prevalence), [LiPyphilic](https://github.com/p-j-smith/lipyphilic), [mici](https://github.com/matt-graham/mici), [optrs](https://github.com/t-young31/opt-rs), [PIXL](https://github.com/UCLH-DIF/PIXL), [pyCascadia](https://github.com/UCL/pyCascadia), [PySilverLabNWB](https://github.com/SilverLabUCL/PySilverLabNWB), [svGPFA](https://github.com/joacorapela/svGPFA), [Thanzi la Onse modelling](https://github.com/UCL/TLOmodel), [SainsburyWellcomeCentre](https://github.com/SainsburyWellcomeCentre/python-cookiecutter), [SciKit-Surgery](https://github.com/SciKit-Surgery) | 🟠 |
-| [conda-forge](https://conda-forge.org)  | Managing environments and dependencies via [conda](https://docs.conda.io/en/latest/) but with a curated list of scientific packages. | [autodE](https://github.com/duartegroup/autodE), [LiPyphilic](https://github.com/p-j-smith/lipyphilic), [SciKit-Surgery](https://github.com/SciKit-Surgery), [SainsburyWellcomeCentre](https://github.com/SainsburyWellcomeCentre/python-cookiecutter) | 🟢 |
-| [GraySkull](https://github.com/conda-incubator/grayskull) | A tool for automatic conda recipe generation (aimed at conda-forge, above). | One-time use tool. | 🟠 |
-| [cibuildwheel](https://cibuildwheel.readthedocs.io) | Builds python wheels for the main operating systems. | [streamtracer](https://github.com/dstansby/streamtracer) | 🟢 |
-
+| ---- | ----------------- | ------- | :---: |
+| [build](https://pypa-build.readthedocs.io/en/stable/) | Straightforward tool to build a Python package. Does not perform dependency management. | | 🟢 |
+| [setuptools](https://setuptools.pypa.io)   | Packaging, distribution, installation. | [autodE](https://github.com/duartegroup/autodE) | 🟠 |
+| [conda-forge](https://conda-forge.org)  | Repository to upload built Python packages. Popular for distributing scientific Python pacakges. |  [LiPyphilic](https://github.com/p-j-smith/lipyphilic) | 🟢 |
+| [GraySkull](https://github.com/conda-incubator/grayskull) | A tool for automatic conda recipe generation (aimed at conda-forge, above). |  | 🟢 |
+| [cibuildwheel](https://cibuildwheel.readthedocs.io) | Builds python wheels for the main operating systems on continuous integration runs (e.g. GitHub actions). | [streamtracer](https://github.com/dstansby/streamtracer) | 🟢 |

--- a/pages/testing.md
+++ b/pages/testing.md
@@ -5,10 +5,17 @@ layout: default
 
 # Testing
 
+## Test runners
+
 | Name     | Short description | 🚦 |
-| -------- | ------------------|---------------|
-| [pytest](https://docs.pytest.org/en/stable/contents.html) | A framework for writing and running tests | 🟢 |
-| [pytest-cov](https://pytest-cov.readthedocs.io/en/latest/index.html) | A framework to generate coverage reports that plays nicely with pytest | 🟢 |
-| [pytest-mock](https://pytest-mock.readthedocs.io/en/latest/index.html) | A framework to mock/patch objects that plays nicely with pytest | 🟢 |
-| [tox](https://tox.wiki/en/latest/index.html) | A framework that allows to run tests and packaging in different environments. | 🟢 |
-| [unittest](https://docs.python.org/dev/library/unittest.html#module-unittest) | A builtin framework for writing and running tests. | 🟠 |
+| -------- | ------------------| :--: |
+| [pytest](https://docs.pytest.org/en/stable/contents.html) | A framework for writing and running tests. | 🟢 |
+| [tox](https://tox.wiki/en/latest/index.html) | A framework that allows running tests and packaging in different environments. | 🟢 |
+| [unittest](https://docs.python.org/dev/library/unittest.html#module-unittest) | A framework built in to Python for writing and running tests. | 🟠 |
+
+## pytest plugins
+
+| Name     | Short description | 🚦 |
+| -------- | ------------------| :--: |
+| [pytest-cov](https://pytest-cov.readthedocs.io/en/latest/index.html) | A framework to generate coverage reports that plays nicely with `pytest`. | 🟢 |
+| [pytest-mock](https://pytest-mock.readthedocs.io/en/latest/index.html) | A framework to mock/patch objects that plays nicely with `pytest`. | 🟢 |


### PR DESCRIPTION
I've just done a general copy edit. In particular this:

- Centers the traffic lights in their column (using `:---:`)
- Splits Documentation, Testing into sub-sections
- Cleans up the linting page quite a bit
- Moves `ruff` from 🟢  to 🟠 , because it duplicates functionality of other tools above that we marked as 🟢 , and is currently less widely used than those tools.
- Clean up examples so there's max one example package per item.