### PR TITLE
Clean packaging page

### DIFF
--- a/pages/packaging.md
+++ b/pages/packaging.md
@@ -7,8 +7,14 @@ layout: default
 
 | Name | Short description | Used by | 🚦 |
 | ---- | ----------------- | ------- | :---: |
-| [build](https://pypa-build.readthedocs.io/en/stable/) | Straightforward tool to build a Python package. Does not perform dependency management. | | 🟢 |
-| [setuptools](https://setuptools.pypa.io)   | Packaging, distribution, installation. | [autodE](https://github.com/duartegroup/autodE) | 🟠 |
-| [conda-forge](https://conda-forge.org)  | Repository to upload built Python packages. Popular for distributing scientific Python pacakges. |  [LiPyphilic](https://github.com/p-j-smith/lipyphilic) | 🟢 |
-| [GraySkull](https://github.com/conda-incubator/grayskull) | A tool for automatic conda recipe generation (aimed at conda-forge, above). |  | 🟢 |
+| [build](https://pypa-build.readthedocs.io/en/stable/) | Straightforward tool to build a Python package. | | 🟢 |
+| [setuptools](https://setuptools.pypa.io) | A widely used build backend, used to configure a Python package. | [autodE](https://github.com/duartegroup/autodE) | 🟢 |
 | [cibuildwheel](https://cibuildwheel.readthedocs.io) | Builds python wheels for the main operating systems on continuous integration runs (e.g. GitHub actions). | [streamtracer](https://github.com/dstansby/streamtracer) | 🟢 |
+
+## Conda
+
+These tools are helpful if you're looking to publish your package on [conda-forge](https://conda-forge.org/), so users can install it through the [conda](https://docs.conda.io/en/latest/) or [mamba](https://mamba.readthedocs.io/en/latest/index.html) package managers.
+
+| Name | Short description | Used by | 🚦 |
+| ---- | ----------------- | ------- | :---: |
+| [GraySkull](https://github.com/conda-incubator/grayskull) | A tool for automatic conda recipe generation (aimed at conda-forge, above). |  | 🟢 |


### PR DESCRIPTION
- Improve descriptions of `build` and `setuptools`
- Make `setuptools` green (almost every Python package uses it!!)
- Create a new `conda` section
- Remove `conda` as it's not a tool, but add a link to it in the blurb in the new Conda section.

Fixes https://github.com/UCL-ARC/python-tooling/issues/40