### PR TITLE
Integrate cookieninja build test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Defines fixtures for tests."""
+
+import pytest
+
+
+@pytest.fixture()
+def project_config():
+    """
+    Pytest fixture for defining the project config.
+
+    Returns
+    -------
+    dict
+        dictionary with values for the cookiecutter template,
+        as defined in the cookiecutter.json
+    """
+    return {
+        "project_slug": "cookiecutter_test",
+    }

--- a/tests/test_package_gen.py
+++ b/tests/test_package_gen.py
@@ -3,24 +3,6 @@
 import subprocess
 from pathlib import Path
 
-import pytest
-
-
-@pytest.fixture()
-def project_config():
-    """
-    Pytest fixture for defining the project config.
-
-    Returns
-    -------
-    dict
-        dictionary with values for the cookiecutter template,
-        as defined in the cookiecutter.json
-    """
-    return {
-        "project_slug": "cookiecutter_test",
-    }
-
 
 def test_package_generation(
     tmp_path: Path,

--- a/tests/test_package_gen.py
+++ b/tests/test_package_gen.py
@@ -1,13 +1,38 @@
+import pathlib as pl
 import subprocess
+
+PROJECT_SLUG = "cookiecutter_test"
 
 
 def test_package_generation(tmpdir):
+    # Run cookieninja with PROJECT_SLUG for project_slug
     subprocess.run(
-        ["cookieninja", ".", "--no-input", "--output-dir", str(tmpdir)],  # noqa: S607
+        [  # noqa: S607
+            "cookieninja",
+            ".",
+            "--no-input",
+            "--output-dir",
+            str(tmpdir),
+            "project_slug=",
+            PROJECT_SLUG,
+        ],
         shell=False,  # noqa: S603
     )
 
+    # Check parent directory of the repo exists
     assert (tmpdir / "python-template").exists()
-    expected_files = ["README.md"]
+
+    # Check files and directories inside
+    expected_files = [
+        "README.md",
+        ".pre-commit-config.yaml",
+        # "LICENSE",
+        "pyproject.toml",
+        # Directories
+        pl.Path("src") / PROJECT_SLUG,
+        "tests",
+        pl.Path(".github"),
+        pl.Path(".github") / "workflows",
+    ]
     for f in expected_files:
-        assert (tmpdir / "python-template" / f).exists()
+        assert (tmpdir / "python-template" / PROJECT_SLUG / f).exists()

--- a/tests/test_package_gen.py
+++ b/tests/test_package_gen.py
@@ -9,9 +9,10 @@ def test_package_generation(
     project_config: dict,
 ):
     """
-    Creates a project cookiecutter from the template.
+    Creates a project from the cookiecutter template.
 
-    Once the project is made it verifies a series of actions work.
+    Once the project is made it verifies a series of files and
+    directories exist.
 
     Args:
     ----
@@ -24,7 +25,7 @@ def test_package_generation(
     Note that 'tmp_path' pytest fixture is preferred over 'tmpdir'
     (see https://docs.pytest.org/en/7.3.x/how-to/tmp_path.html#the-tmpdir-and-tmpdir-factory-fixtures)
     """
-    # Run cookieninja with PROJECT_SLUG for project_slug
+    # Run cookieninja with project_slug set to the value in the project config
     subprocess.run(
         [  # noqa: S607
             "cookieninja",
@@ -40,7 +41,7 @@ def test_package_generation(
     # Check parent directory exists
     assert (tmp_path / project_config["project_slug"]).exists()
 
-    # Check files and directories inside
+    # Check main files and directories inside parent directory
     expected_files = [
         "README.md",
         ".pre-commit-config.yaml",

--- a/tests/test_package_gen.py
+++ b/tests/test_package_gen.py
@@ -1,10 +1,17 @@
 import pathlib as pl
 import subprocess
 
-PROJECT_SLUG = "cookiecutter_test"
+import pytest
 
 
-def test_package_generation(tmp_path):
+@pytest.fixture
+def project_config():
+    return {
+        "project_slug": "cookiecutter_test",
+    }
+
+
+def test_package_generation(tmp_path, project_config):
     # tmp_path fixture preferred over tmpdir
     # see https://docs.pytest.org/en/7.3.x/how-to/tmp_path.html#the-tmpdir-and-tmpdir-factory-fixtures
 
@@ -16,26 +23,25 @@ def test_package_generation(tmp_path):
             "--no-input",
             "--output-dir",
             str(tmp_path),
-            f"project_slug={PROJECT_SLUG}",
+            f"project_slug={project_config['project_slug']}",
         ],
         shell=False,  # noqa: S603
     )
 
     # Check parent directory exists
-    assert (tmp_path / PROJECT_SLUG).exists()
+    assert (tmp_path / project_config["project_slug"]).exists()
 
     # Check files and directories inside
     expected_files = [
         "README.md",
         ".pre-commit-config.yaml",
-        # "LICENSE",
+        "LICENSE.md",
         "pyproject.toml",
-        # Directories
         "src",
-        pl.Path("src") / PROJECT_SLUG,
+        pl.Path("src") / project_config["project_slug"],
         "tests",
         pl.Path(".github"),
         pl.Path(".github") / "workflows",
     ]
     for f in expected_files:
-        assert (tmp_path / PROJECT_SLUG / f).exists()
+        assert (tmp_path / project_config["project_slug"] / f).exists()

--- a/tests/test_package_gen.py
+++ b/tests/test_package_gen.py
@@ -4,7 +4,10 @@ import subprocess
 PROJECT_SLUG = "cookiecutter_test"
 
 
-def test_package_generation(tmpdir):
+def test_package_generation(tmp_path):
+    # tmp_path fixture preferred over tmpdir
+    # see https://docs.pytest.org/en/7.3.x/how-to/tmp_path.html#the-tmpdir-and-tmpdir-factory-fixtures
+
     # Run cookieninja with PROJECT_SLUG for project_slug
     subprocess.run(
         [  # noqa: S607
@@ -12,15 +15,14 @@ def test_package_generation(tmpdir):
             ".",
             "--no-input",
             "--output-dir",
-            str(tmpdir),
-            "project_slug=",
-            PROJECT_SLUG,
+            str(tmp_path),
+            f"project_slug={PROJECT_SLUG}",
         ],
         shell=False,  # noqa: S603
     )
 
-    # Check parent directory of the repo exists
-    assert (tmpdir / "python-template").exists()
+    # Check parent directory exists
+    assert (tmp_path / PROJECT_SLUG).exists()
 
     # Check files and directories inside
     expected_files = [
@@ -29,10 +31,11 @@ def test_package_generation(tmpdir):
         # "LICENSE",
         "pyproject.toml",
         # Directories
+        "src",
         pl.Path("src") / PROJECT_SLUG,
         "tests",
         pl.Path(".github"),
         pl.Path(".github") / "workflows",
     ]
     for f in expected_files:
-        assert (tmpdir / "python-template" / PROJECT_SLUG / f).exists()
+        assert (tmp_path / PROJECT_SLUG / f).exists()

--- a/tests/test_package_gen.py
+++ b/tests/test_package_gen.py
@@ -1,7 +1,7 @@
 """Checks that the cookiecutter works."""
 
-import pathlib as pl
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -23,7 +23,7 @@ def project_config():
 
 
 def test_package_generation(
-    tmp_path: pl.Path,
+    tmp_path: Path,
     project_config: dict,
 ):
     """
@@ -31,12 +31,16 @@ def test_package_generation(
 
     Once the project is made it verifies a series of actions work.
 
-    tmp_path pytest fixture preferred over tmpdir
-    see https://docs.pytest.org/en/7.3.x/how-to/tmp_path.html#the-tmpdir-and-tmpdir-factory-fixtures
-
     Args:
     ----
-        tmpdir: A temporary directory path object which is unique.
+        tmp_path: Path
+            A temporary directory path object which is unique.
+        project_config: dict
+            A dictionary with values for the cookiecutter template,
+            as defined in the cookiecutter.json
+
+    Note that 'tmp_path' pytest fixture is preferred over 'tmpdir'
+    (see https://docs.pytest.org/en/7.3.x/how-to/tmp_path.html#the-tmpdir-and-tmpdir-factory-fixtures)
     """
     # Run cookieninja with PROJECT_SLUG for project_slug
     subprocess.run(
@@ -61,10 +65,10 @@ def test_package_generation(
         "LICENCE.md",
         "pyproject.toml",
         "src",
-        pl.Path("src") / project_config["project_slug"],
+        Path("src") / project_config["project_slug"],
         "tests",
-        pl.Path(".github"),
-        pl.Path(".github") / "workflows",
+        Path(".github"),
+        Path(".github") / "workflows",
     ]
     for f in expected_files:
         assert (tmp_path / project_config["project_slug"] / f).exists()

--- a/tests/test_package_gen.py
+++ b/tests/test_package_gen.py
@@ -58,7 +58,7 @@ def test_package_generation(
     expected_files = [
         "README.md",
         ".pre-commit-config.yaml",
-        "LICENSE.md",
+        "LICENCE.md",
         "pyproject.toml",
         "src",
         pl.Path("src") / project_config["project_slug"],


### PR DESCRIPTION
Part of the tests tox runs from gh actions.

Run cookieninja to build a test project and check the basic files are generated.

Will fix #20 

with @yidilozdemir 