### PR TITLE
Just require minimum python version

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -44,7 +44,7 @@ optional-dependencies = {dev = [
     "twine",
 ]}
 readme = "README.md"
-requires-python = ">={{ cookiecutter.min_python_version }}, <={{ cookiecutter.max_python_version }}"
+requires-python = ">={{ cookiecutter.min_python_version }}"
 license.file = "LICENCE.md"
 urls.homepage = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}"
 


### PR DESCRIPTION
This way a user is free to use `3.12` for example but it's just that the package officially only supports up to, e.g. `3.11`.