### PR TITLE
Add setuptools-scm to the tooling docs

### DIFF
--- a/docs/pages/packaging.md
+++ b/docs/pages/packaging.md
@@ -5,12 +5,12 @@ layout: default
 
 # Packaging
 
-| Name                                                  | Short description                                                                                         | Used by                                                  | 🚦  |
-| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- | :-: |
-| [build](https://pypa-build.readthedocs.io/en/stable/) | Straightforward tool to build a Python package.                                                           |                                                          | 🟢  |
-| [setuptools](https://setuptools.pypa.io)              | A widely used build backend, used to configure a Python package.                                          | [autodE](https://github.com/duartegroup/autodE)          | 🟢  |
-| [setuptools-scm](https://github.com/pypa/setuptools_scm/)              | Provides automatic versioning Python packages. Also automatically adds all files under source control to the sdist / wheel.                                           | [btrack](https://github.com/quantumjot/btrack)          | 🟢  |
-| [cibuildwheel](https://cibuildwheel.readthedocs.io)   | Builds python wheels for the main operating systems on continuous integration runs (e.g. GitHub actions). | [streamtracer](https://github.com/dstansby/streamtracer) | 🟢  |
+| Name                                                      | Short description                                                                                                           | Used by                                                  | 🚦  |
+| --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- | :-: |
+| [build](https://pypa-build.readthedocs.io/en/stable/)     | Straightforward tool to build a Python package.                                                                             |                                                          | 🟢  |
+| [setuptools](https://setuptools.pypa.io)                  | A widely used build backend, used to configure a Python package.                                                            | [autodE](https://github.com/duartegroup/autodE)          | 🟢  |
+| [setuptools-scm](https://github.com/pypa/setuptools_scm/) | Provides automatic versioning Python packages. Also automatically adds all files under source control to the sdist / wheel. | [btrack](https://github.com/quantumjot/btrack)           | 🟢  |
+| [cibuildwheel](https://cibuildwheel.readthedocs.io)       | Builds python wheels for the main operating systems on continuous integration runs (e.g. GitHub actions).                   | [streamtracer](https://github.com/dstansby/streamtracer) | 🟢  |
 
 ## Conda
 

--- a/docs/pages/packaging.md
+++ b/docs/pages/packaging.md
@@ -9,6 +9,7 @@ layout: default
 | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- | :-: |
 | [build](https://pypa-build.readthedocs.io/en/stable/) | Straightforward tool to build a Python package.                                                           |                                                          | 🟢  |
 | [setuptools](https://setuptools.pypa.io)              | A widely used build backend, used to configure a Python package.                                          | [autodE](https://github.com/duartegroup/autodE)          | 🟢  |
+| [setuptools-scm](https://github.com/pypa/setuptools_scm/)              | Provides automatic versioning Python packages. Also automatically adds all files under source control to the sdist / wheel.                                           | [btrack](https://github.com/quantumjot/btrack)          | 🟢  |
 | [cibuildwheel](https://cibuildwheel.readthedocs.io)   | Builds python wheels for the main operating systems on continuous integration runs (e.g. GitHub actions). | [streamtracer](https://github.com/dstansby/streamtracer) | 🟢  |
 
 ## Conda


### PR DESCRIPTION
Fixes #98 

Add `setuptools-scm` to the packaging page of the docs