### PR TITLE
Another attempt to reduce GitHub notfications (`renovate`)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,10 +3,9 @@
   "extends": ["config:base", ":disableDependencyDashboard", ":enablePreCommit"],
   "packageRules": [
     {
-      "matchUpdateTypes": ["digest", "minor", "patch", "pin"],
-      "automerge": true
+      "automerge": true,
+      "automergeType": "branch",
+      "matchUpdateTypes": ["digest", "minor", "patch", "pin"]
     }
-  ],
-  "autoApprove": true,
-  "platformAutomerge": true
+  ]
 }


### PR DESCRIPTION
For context @samcunliffe and I got emails that `pre-commit` has updated, then have to approve, then it merges by itself.

Not fully sure what goes in `packageRules` and what doesn't.

From the [description about noise reduction](https://docs.renovatebot.com/noise-reduction/#branch-automerging), this approach sounds ideal.

Another approach could be the [renovate-approve bot](https://github.com/apps/renovate-approve) discussed in this [stackoverflow](https://github.com/renovatebot/renovate/issues/2446#issuecomment-417274246) - seems like the fundamental issue is users being unable to approve their own PR (which is fair enough).

Seems like there is a [gitLabIgnoreApprovals specific setting](https://docs.renovatebot.com/configuration-options/#gitlabignoreapprovals) which would get around this. So presumably `GitLab` does allow users to approve PRs?

Anyway, let's get this in and see if it works. We _could_ even turn off the non-major updates, as it would raise a PR if it fails. What do you think?