### PR TITLE
Write a coverage report when running tox

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -153,7 +153,7 @@ legacy_tox_ini = """
 
     [testenv]
     commands =
-        pytest --cov
+        pytest --cov --cov-report=xml
     deps =
         pytest
         pytest-cov


### PR DESCRIPTION
When setting up code coverage, I noticed there wasn't a coverage file written that codecov could use. This fixes that by writing an xml coverage file.