### PR TITLE
Explicitly specify mypy config file in pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
     hooks:
       - id: mypy
         args: [--config-file, pyproject.toml]
+        additional_dependencies: ["pytest"]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
     rev: v1.4.1
     hooks:
       - id: mypy
+        args: [--config-file, pyproject.toml]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.1
     hooks:


### PR DESCRIPTION
I've found that without this `mypy` doesn't read the configuration when pre-commit is run.