### PR TITLE
Remove pydantic from pyproject.toml

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -59,7 +59,6 @@ paths.source = [
 explicit_package_bases = true
 plugins = [
     "numpy.typing.mypy_plugin",
-    "pydantic.mypy",
 ]
 
 [tool.pytest.ini_options]
@@ -127,7 +126,6 @@ isort.known-first-party = [
 mccabe.max-complexity = 18
 pep8-naming.classmethod-decorators = [
     "classmethod",
-    "pydantic.validator",
 ]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Since not all projects will use `pydantic`, I think it makes sense to remove these lines from `pyproject.toml`? In a new project I started I'm getting errors complaining that mypy can't find pydantic, and I don't want to install pydantic because I don't need it for the project.