### PR TITLE
Simplify `renovate` config & shortern commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", ":disableDependencyDashboard", ":enablePreCommit"],
+  "extends": [
+    "config:base",
+    ":automergeBranch",
+    ":automergeDigest",
+    ":automergeMinor",
+    ":automergePatch",
+    ":disableDependencyDashboard",
+    ":enablePreCommit"
+  ],
+  "commitMessageAction": "Renovate:",
   "packageRules": [
     {
-      "description": "Automatically merge minor and patch-level updates",
-      "automerge": true,
-      "automergeType": "branch",
-      "matchUpdateTypes": ["digest", "minor", "patch"],
-      "platformAutomerge": true
+      "commitMessageTopic": "{{depName}}",
+      "matchManagers": ["github-actions", "pre-commit"]
     }
   ]
 }


### PR DESCRIPTION
Don't you hate it when PR(/commit) messages are over 80 chars and don't render well on GitHub? Well have I got a solution for you!