### PR TITLE
Use default coverage

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,19 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base",
-    ":automergeBranch",
-    ":automergeDigest",
-    ":automergeMinor",
-    ":automergePatch",
-    ":disableDependencyDashboard",
-    ":enablePreCommit"
-  ],
-  "commitMessageAction": "Renovate:",
-  "packageRules": [
-    {
-      "commitMessageTopic": "{{depName}}",
-      "matchManagers": ["github-actions", "pre-commit"]
-    }
-  ]
+  "extends": ["github>UCL-ARC/renovate-config"]
 }


### PR DESCRIPTION
Turns out you can have a default setting repo which we can re-use. Seems like this would be useful for other projects too, and will keep them up-to-date.

https://docs.renovatebot.com/config-presets/#github-hosted-presets