### PR TITLE
Use pre-commit.ci for linting repository

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,29 +8,6 @@ on:
   pull_request:
 
 jobs:
-  lint-this-repo:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-
-      - name: Cache pre-commit
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-
-      - name: Set up python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.x"
-
-      - name: Install dependencies
-        run: python -m pip install pre-commit
-
-      - name: Run pre-commit
-        run: pre-commit run --all-files --color always --verbose
-
   lint-the-template:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I set up https://pre-commit.ci/ to run pre-commit on the repository. The advantage of this over github actions is you can leave a comment that says "pre-commit.ci autofix" on the PR, and it will push a commit that fixes any issues that can be automatically fixed.

I left the GH actions job that lints the template after a package is generated, as I don't think there's a way to replace that.