### PR TITLE
Add missing `3.12`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ legacy_tox_ini = """
         3.9: py39
         3.10: py310
         3.11: py311
+        3.12: py312
 
     [testenv]
     skip_install = true
@@ -88,5 +89,5 @@ legacy_tox_ini = """
         pytest {posargs}
 
     [tox]
-    env_list = py3{8,9,10,11}
+    env_list = py3{9,10,11,12}
 """


### PR DESCRIPTION
Sorry for the rant, but can you please search for `3.11`/`311` next time when you make a change? Can easily miss. Fixes #189, #194.