### PR TITLE
Remove `additional_dependencies`

### DIFF
--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -16,7 +16,6 @@ repos:
     rev: v1.6.1
     hooks:
       - id: mypy
-        additional_dependencies: [numpy, pydantic]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.3
     hooks:


### PR DESCRIPTION
I added these originally to make it clear how to do it for those not familiar. But perhaps it is better without.

Split up #207