### PR TITLE
Revert "Renovate the templates workflows (#226)"

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,10 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>UCL-ARC/.github//renovate/default-config.json"],
-  "github-actions": {
-    "fileMatch": [
-      "{{cookiecutter.project_slug}}/.github/workflows/[^/]+\\.ya?ml$"
-    ]
-  },
   "reviewers": ["paddyroddy", "samcunliffe", "sfmig"]
 }


### PR DESCRIPTION
This reverts commit 7ce56ce9305c7d826204019301acfdeabf09609f.

Following renovatebot/renovate#25813 we shouldn't need this any more.