### PR TITLE
Temporarily revert renovate updates.

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -67,4 +67,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -53,7 +53,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v2
         with:
           path: docs/_site
 


### PR DESCRIPTION
I was too hasty in merging #233, this needs `actions/upload-artifact@v4`. #234 only updated `actions/upload-pages-artifact` to _its_ `v3` which is only  `actions/upload-artifact@v3` under the hood.

This PR just reverts the last two commits and downgrades the two actions. We can live with old versions until https://github.com/actions/upload-pages-artifact/pull/76 is merged and makes it into production. Then we can re-update.

Also, all of this wasn't caught in CI because we don't test the webpage deployment in CI. (For obvious reasons.)

In terms of the doc failure, it does ["fail" in the step before](https://github.com/UCL-ARC/python-tooling/actions/runs/7265323304/job/19794807367#step:6:65) deployment where the upload action doesn't upload. We might want to investigate a `--no-really-we-want-any-error-as-a-fail` option and/or add the doc build to the required checks (I don't think that would have caught this bug, but we probably want to run it anyway).