### PR TITLE
Add issue templates to this project & the template

### DIFF
--- a/.github/ISSUE_TEMPLATES/bug_report.yml
+++ b/.github/ISSUE_TEMPLATES/bug_report.yml
@@ -1,0 +1,62 @@
+---
+name: Bug Report
+description: Create a Report to Help us Improve
+title: "[BUG]: "
+labels:
+  - bug
+assignees:
+  - paddyroddy
+  - samcunliffe
+body:
+  - id: describe
+    type: textarea
+    attributes:
+      label: Describe the Bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - id: reproduce
+    type: textarea
+    attributes:
+      label: To Reproduce
+      description: >-
+        A minimal working example of code to reproduce the unexpected behaviour.
+    validations:
+      required: true
+  - id: expected
+    type: textarea
+    attributes:
+      label: Expected Behaviour
+      description: >-
+        A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - id: actual
+    type: textarea
+    attributes:
+      label: Actual Behaviour
+      description: >-
+        Be a specific and detailed as you can.
+        Paste any output or stack traces of errors you receive.
+    validations:
+      required: true
+  # - id: version
+  #   type: input
+  #   attributes:
+  #     label: Version In Use
+  #     description: |-
+  #       Can be found by
+  #       ```sh
+  #       python -c "import sleplet; print(sleplet.__version__)"
+  #       ```
+  #   validations:
+  #     required: true
+  - id: additional
+    type: textarea
+    attributes:
+      label: Additional Context
+      value: |-
+        - Cookiecutter version:
+        - Operating system:
+        - Python version:
+      render: markdown

--- a/.github/ISSUE_TEMPLATES/config.yml
+++ b/.github/ISSUE_TEMPLATES/config.yml
@@ -1,0 +1,2 @@
+---
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATES/documentation.yml
+++ b/.github/ISSUE_TEMPLATES/documentation.yml
@@ -1,0 +1,31 @@
+---
+name: Documentation
+description: How Can We Improve the Documentation
+title: "[DOCS]: "
+labels:
+  - documentation
+assignees:
+  - paddyroddy
+  - samcunliffe
+body:
+  - id: section
+    type: textarea
+    attributes:
+      label: Which Section of the Documentation Needs Improving?
+      description: Please provide a link (if it is a specific page).
+    validations:
+      required: true
+  - id: problem
+    type: textarea
+    attributes:
+      label: What Can be Improved About This Section
+      description: Is it incomplete, incorrect or difficult to understand?
+    validations:
+      required: true
+  - id: suggestions
+    type: textarea
+    attributes:
+      label: How to Improve This Section
+      description: >-
+        Do you have any specific suggestions we
+        could take to improve the documentation?

--- a/.github/ISSUE_TEMPLATES/feature_request.yml
+++ b/.github/ISSUE_TEMPLATES/feature_request.yml
@@ -1,0 +1,38 @@
+---
+name: Feature Request
+description: Suggest a Way to Improve This Project
+title: "[FEATURE]: "
+labels:
+  - enhancement
+assignees:
+  - paddyroddy
+  - samcunliffe
+body:
+  - id: problem
+    type: textarea
+    attributes:
+      label: Is Your Feature Request Related to a Problem? Please Describe
+      description: A clear and concise description of what the problem is.
+      placeholder: I'm always frustrated when [...]
+    validations:
+      required: true
+  - id: solution
+    type: textarea
+    attributes:
+      label: Describe the Solution You'd Like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - id: alternatives
+    type: textarea
+    attributes:
+      label: Describe Alternatives You've Considered
+      description: >-
+        A clear and concise description of any alternative
+        solutions or features you've considered.
+  - id: additional
+    type: textarea
+    attributes:
+      label: Additional Context
+      description: >-
+        Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATES/question.yml
+++ b/.github/ISSUE_TEMPLATES/question.yml
@@ -1,0 +1,28 @@
+---
+name: Question
+description: General Questions About Using the Cookiecutter Template
+title: "[QUESTION]: "
+labels:
+  - question
+assignees:
+  - paddyroddy
+  - samcunliffe
+body:
+  - id: topic
+    type: dropdown
+    attributes:
+      label: What is the Topic of Your Question
+      description: Please indicate the topic in the title of your question.
+      options:
+        - Installation
+        - Usage
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - id: question
+    type: textarea
+    attributes:
+      label: Add Your Question Below
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATES/website.yml
+++ b/.github/ISSUE_TEMPLATES/website.yml
@@ -1,0 +1,31 @@
+---
+name: Website
+description: How Can We Improve the Website
+title: "[WEBSITE]: "
+labels:
+  - website
+assignees:
+  - paddyroddy
+  - samcunliffe
+body:
+  - id: section
+    type: textarea
+    attributes:
+      label: Which Section of the Website Needs Improving?
+      description: Please provide a link (if it is a specific page).
+    validations:
+      required: true
+  - id: problem
+    type: textarea
+    attributes:
+      label: What Can be Improved About This Section
+      description: Is it incomplete, incorrect or difficult to understand?
+    validations:
+      required: true
+  - id: suggestions
+    type: textarea
+    attributes:
+      label: How to Improve This Section
+      description: >-
+        Do you have any specific suggestions we
+        could take to improve the website?

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATES/bug_report.yml
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATES/bug_report.yml
@@ -1,0 +1,67 @@
+---
+name: Bug Report
+description: Create a Report to Help us Improve
+title: "[BUG]: "
+labels:
+  - bug
+assignees:
+  - "{{cookiecutter.github_username}}"
+body:
+  - id: describe
+    type: textarea
+    attributes:
+      label: Describe the Bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - id: reproduce
+    type: textarea
+    attributes:
+      label: To Reproduce
+      description: >-
+        A minimal working example of code to reproduce the unexpected behaviour,
+        this will render as `Python` code so no need for backticks.
+      value: |-
+        import {{cookiecutter.package_name}}
+
+        ...
+      render: python
+    validations:
+      required: true
+  - id: expected
+    type: textarea
+    attributes:
+      label: Expected Behaviour
+      description: >-
+        A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - id: actual
+    type: textarea
+    attributes:
+      label: Actual Behaviour
+      description: >-
+        Be a specific and detailed as you can.
+        Paste any output or stack traces of errors you receive.
+    validations:
+      required: true
+  - id: version
+    type: input
+    attributes:
+      label: Version In Use
+      description: |-
+        Can be found by
+        ```sh
+        python -c "import {{cookiecutter.package_name}};
+                   print({{cookiecutter.package_name}}.__version__)"
+        ```
+    validations:
+      required: true
+  - id: additional
+    type: textarea
+    attributes:
+      label: Additional Context
+      value: |-
+        - Python version:
+        - Operating system:
+      render: markdown

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATES/config.yml
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATES/config.yml
@@ -1,0 +1,2 @@
+---
+blank_issues_enabled: false

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATES/documentation.yml
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATES/documentation.yml
@@ -1,0 +1,30 @@
+---
+name: Documentation
+description: How Can We Improve the Documentation
+title: "[DOCS]: "
+labels:
+  - documentation
+assignees:
+  - "{{cookiecutter.github_username}}"
+body:
+  - id: section
+    type: textarea
+    attributes:
+      label: Which Section of the Documentation Needs Improving?
+      description: Please provide a link (if it is a specific page).
+    validations:
+      required: true
+  - id: problem
+    type: textarea
+    attributes:
+      label: What Can be Improved About This Section
+      description: Is it incomplete, incorrect or difficult to understand?
+    validations:
+      required: true
+  - id: suggestions
+    type: textarea
+    attributes:
+      label: How to Improve This Section
+      description: >-
+        Do you have any specific suggestions we
+        could take to improve the documentation?

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATES/feature_request.yml
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATES/feature_request.yml
@@ -1,0 +1,37 @@
+---
+name: Feature Request
+description: Suggest a Way to Improve This Project
+title: "[FEATURE]: "
+labels:
+  - enhancement
+assignees:
+  - "{{cookiecutter.github_username}}"
+body:
+  - id: problem
+    type: textarea
+    attributes:
+      label: Is Your Feature Request Related to a Problem? Please Describe
+      description: A clear and concise description of what the problem is.
+      placeholder: I'm always frustrated when [...]
+    validations:
+      required: true
+  - id: solution
+    type: textarea
+    attributes:
+      label: Describe the Solution You'd Like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - id: alternatives
+    type: textarea
+    attributes:
+      label: Describe Alternatives You've Considered
+      description: >-
+        A clear and concise description of any alternative
+        solutions or features you've considered.
+  - id: additional
+    type: textarea
+    attributes:
+      label: Additional Context
+      description: >-
+        Add any other context or screenshots about the feature request here.

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATES/question.yml
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATES/question.yml
@@ -1,12 +1,11 @@
 ---
 name: Question
-description: General Questions About Using the Cookiecutter Template
+description: General Questions About Using {{cookiecutter.project_name}}
 title: "[QUESTION]: "
 labels:
   - question
 assignees:
-  - paddyroddy
-  - samcunliffe
+  - "{{cookiecutter.github_username}}"
 body:
   - id: topic
     type: dropdown
@@ -17,7 +16,6 @@ body:
         - Documentation
         - Installation
         - Usage
-        - Website
         - Other
     validations:
       required: true


### PR DESCRIPTION
This PR adds issue templates for this project for:
- bug report
- documentation
- feature request
- question
- website

and also for the template:
- bug report
- documentation
- feature request
- question

These have been copied over & modified from https://github.com/astro-informatics/sleplet. So the [new cool GitHub issue template forms have been tested/tried out](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms].