### PR TITLE
Adding logo to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# UCL ARC Python Recommendations
+<div style="text-align: center;" align="center">
+  <img src="https://raw.githubusercontent.com/UCL-ARC/python-tooling/main/images/logo.svg" alt="UCL ARC Python tooling logo" width="120"/>
+  <h1> UCL ARC Python recommendations</h1>
+</div>
 
 This repository collects the [UCL ARC] recommendations for a Research Software
 project in Python. It contains a template for new Python packages and a


### PR DESCRIPTION
Follow on from #277 - adds logo to README file. Hopefully link checker will now not fail as logo file now on `main` 🤞.