### PR TITLE
Add `importlib` to `pytest`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [tool.pytest.ini_options]
-addopts = "--color=yes -vv"
+addopts = """
+    --color=yes
+    --import-mode=importlib
+    --verbose
+"""
 testpaths = [
     "tests",
 ]

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -61,7 +61,11 @@ plugins = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--color=yes -v"
+addopts = """
+    --color=yes
+    --import-mode=importlib
+    --verbose
+"""
 testpaths = [
     "tests",
 ]


### PR DESCRIPTION
Fixes #223. See an explanation on `importlib` on the docs https://docs.pytest.org/en/stable/explanation/pythonpath.html