### PR TITLE
Top-level LICENSE → LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-# The MIT License (MIT)
+# MIT License
 
 Copyright (c) 2023-2024 UCL Centre for Advanced Research Computing
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
-MIT License
+# The MIT License (MIT)
 
-Copyright (c) 2023 UCL  Advanced Research Computing Centre
+Copyright (c) 2023-2024 UCL Centre for Advanced Research Computing
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/{{cookiecutter.project_slug}}/LICENSE.md
+++ b/{{cookiecutter.project_slug}}/LICENSE.md
@@ -1,6 +1,6 @@
 {%- if cookiecutter.license == "MIT" -%}
 
-# The MIT License (MIT)
+# MIT License
 
 Copyright (c) {% now 'utc', '%Y' %} {{cookiecutter.author_given_names}} {{cookiecutter.author_family_names}}
 


### PR DESCRIPTION
Title changed to be consistent with [SPDX](https://spdx.org/licenses/MIT.html) and [choosealicense](https://choosealicense.com/licenses/mit/).

NAL but I think the title isn't part of the license and the exact phrasing "doesn't matter" (but let's have it consistent and correct anyway).

Solves 
* #291 