### PR TITLE
Remove default prefixes from issue titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 description: Create a Report to Help us Improve
-title: "[BUG]: "
+title: ""
 labels:
   - bug
 assignees:

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,7 +1,7 @@
 ---
 name: Documentation
 description: How Can We Improve the Documentation
-title: "[DOCS]: "
+title: ""
 labels:
   - documentation
 assignees:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 description: Suggest a Way to Improve This Project
-title: "[FEATURE]: "
+title: ""
 labels:
   - enhancement
 assignees:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,7 +1,7 @@
 ---
 name: Question
 description: General Questions About Using the Cookiecutter Template
-title: "[QUESTION]: "
+title: ""
 labels:
   - question
 assignees:

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,7 +1,7 @@
 ---
 name: Task
 description: A Task to be Completed
-title: "[TASK]: "
+title: ""
 labels:
   - task
 assignees:

--- a/.github/ISSUE_TEMPLATE/website.yml
+++ b/.github/ISSUE_TEMPLATE/website.yml
@@ -1,7 +1,7 @@
 ---
 name: Website
 description: How Can We Improve the Website
-title: "[WEBSITE]: "
+title: ""
 labels:
   - website
 assignees:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 
 #default project path
 python-template
+
+*.DS_Store


### PR DESCRIPTION
Personally I find the list of issues much harder to read when it has these all upper case prefixes, and since issues are labelled with their category anyway, adding these prefixes is duplicating that info.