### PR TITLE
Update link to ARC website

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ To contribute a change, please:
 
 <!-- prettier-ignore-start -->
 [website]: https://github-pages.arc.ucl.ac.uk/python-tooling
-[UCL ARC]: https://ucl.ac.uk/arc
+[UCL ARC]: https://www.ucl.ac.uk/advanced-research-computing
 [open an issue]: https://github.com/UCL-ARC/python-tooling/issues/new/choose
 [Discussions tab]: https://github.com/UCL-ARC/python-tooling/discussions
 [Research software engineers]: https://society-rse.org/about/history


### PR DESCRIPTION
https://www.ucl.ac.uk/arc redirects to https://www.ucl.ac.uk/advanced-research-computing, so update the link in `CONTRIBUTING.md`.