### PR TITLE
Change github_user to github_user_or_org

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,7 +7,7 @@
   "package_name": "{{cookiecutter.project_slug.replace('-', '_')}}",
   "project_short_description": "A cookiecutter template with ARC recommendations.",
   "initialise_git_repository": true,
-  "github_username": "{{cookiecutter.author_given_names.lower().replace(' ', '-')}}-{{cookiecutter.author_family_names.lower().replace(' ', '-')}}",
+  "github_user_or_org": "{{cookiecutter.author_given_names.lower().replace(' ', '-')}}-{{cookiecutter.author_family_names.lower().replace(' ', '-')}}",
   "min_python_version": ["3.9", "3.10", "3.11", "3.12"],
   "max_python_version": ["3.12", "3.11", "3.10", "3.9"],
   "license": ["MIT", "BSD-3", "GPL-3.0"],

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -61,7 +61,7 @@ def main(initialise_git_repository: str) -> int:
             print(
                 "GitHub CLI detected, you can create a repo with the following:\n\n"
                 "gh repo create "
-                "{{cookiecutter.github_username}}/{{cookiecutter.project_slug}} "
+                "{{cookiecutter.github_user_or_org}}/{{cookiecutter.project_slug}} "
                 "-d '{{cookiecutter.project_short_description}}' "
                 "--public "
                 "-r origin "
@@ -72,12 +72,12 @@ def main(initialise_git_repository: str) -> int:
             print(
                 "You now have a local git repository. To sync this to GitHub "
                 "you need to create an empty GitHub repo with the name "
-                "{{cookiecutter.github_username}}/{{cookiecutter.project_slug}} "
+                "{{cookiecutter.github_user_or_org}}/{{cookiecutter.project_slug}} "
                 "- DO NOT SELECT ANY OTHER OPTION.\n\nSee this link for more detail "
                 "https://docs.github.com/en/get-started/quickstart/create-a-repo.\n\n"
                 "Then run:\n\n"
                 "git remote add origin git@github.com:"
-                "{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}.git"
+                "{{cookiecutter.github_user_or_org}}/{{cookiecutter.project_slug}}.git"
             )
         except subprocess.CalledProcessError as e:
             # some other error

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ def project_config() -> dict:
 
     """
     return {
-        "github_username": "test-user",
+        "github_user_or_org": "test-user",
         "project_short_description": "description",
         "project_name": "Cookiecutter Test",
         "expected_repo_name": "cookiecutter-test",

--- a/tests/test_git_init.py
+++ b/tests/test_git_init.py
@@ -34,7 +34,7 @@ def test_initialisation_of_git_repo(
             "--no-input",
             "--output-dir",
             f"{tmp_path}",
-            f"github_username={project_config['github_username']}",
+            f"github_user_or_org={project_config['github_user_or_org']}",
             f"project_name={project_config['project_name']}",
             f"project_short_description={project_config['project_short_description']}",
             git_init_cookiecutter_option,
@@ -75,7 +75,7 @@ def test_initialisation_of_git_repo(
             )
             assert (
                 "GitHub CLI detected, you can create a repo with the following:\n\n"
-                f"gh repo create {project_config['github_username']}/"
+                f"gh repo create {project_config['github_user_or_org']}/"
                 f"{project_config['expected_repo_name']} -d "
                 f"'{project_config['project_short_description']}' --public -r "
                 f"origin --source {project_config['expected_repo_name']}"
@@ -88,12 +88,12 @@ def test_initialisation_of_git_repo(
             assert (
                 "You now have a local git repository. To sync this to GitHub you "
                 "need to create an empty GitHub repo with the name "
-                f"{project_config['github_username']}/"
+                f"{project_config['github_user_or_org']}/"
                 f"{project_config['expected_repo_name']} - DO NOT SELECT ANY "
                 "OTHER OPTION.\n\nSee this link for more detail "
                 "https://docs.github.com/en/get-started/quickstart/create-a-repo"
                 ".\n\nThen run:\n\ngit remote add origin git@github.com:"
-                f"{project_config['github_username']}/"
+                f"{project_config['github_user_or_org']}/"
                 f"{project_config['expected_repo_name']}.git" in cookie.stdout
             )
     else:

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,7 @@ title: "[BUG]: "
 labels:
   - bug
 assignees:
-  - "{{cookiecutter.github_username}}"
+  - "{{cookiecutter.github_user_or_org}}"
 body:
   - id: describe
     type: textarea

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/documentation.yml
@@ -5,7 +5,7 @@ title: "[DOCS]: "
 labels:
   - documentation
 assignees:
-  - "{{cookiecutter.github_username}}"
+  - "{{cookiecutter.github_user_or_org}}"
 body:
   - id: section
     type: textarea

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,7 +5,7 @@ title: "[FEATURE]: "
 labels:
   - enhancement
 assignees:
-  - "{{cookiecutter.github_username}}"
+  - "{{cookiecutter.github_user_or_org}}"
 body:
   - id: problem
     type: textarea

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/question.yml
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/question.yml
@@ -5,7 +5,7 @@ title: "[QUESTION]: "
 labels:
   - question
 assignees:
-  - "{{cookiecutter.github_username}}"
+  - "{{cookiecutter.github_user_or_org}}"
 body:
   - id: topic
     type: dropdown

--- a/{{cookiecutter.project_slug}}/CITATION.cff
+++ b/{{cookiecutter.project_slug}}/CITATION.cff
@@ -5,6 +5,6 @@ authors:
   - family-names: "{{cookiecutter.author_family_names }}"
     given-names: "{{ cookiecutter.author_given_names }}"
     email: "{{ cookiecutter.author_email }}"
-repository-code: "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}"
+repository-code: "https://github.com/{{ cookiecutter.github_user_or_org }}/{{ cookiecutter.project_slug }}"
 title: "{{ cookiecutter.project_name }}: {{ cookiecutter.project_short_description }}"
 license: "{{ cookiecutter.license }}"

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -12,10 +12,10 @@
 -->
 
 <!-- prettier-ignore-start -->
-[tests-badge]:              https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}/actions/workflows/tests.yml/badge.svg
-[tests-link]:               https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}/actions/workflows/tests.yml
-[linting-badge]:            https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}/actions/workflows/linting.yml/badge.svg
-[linting-link]:             https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}/actions/workflows/linting.yml
+[tests-badge]:              https://github.com/{{cookiecutter.github_user_or_org}}/{{cookiecutter.project_slug}}/actions/workflows/tests.yml/badge.svg
+[tests-link]:               https://github.com/{{cookiecutter.github_user_or_org}}/{{cookiecutter.project_slug}}/actions/workflows/tests.yml
+[linting-badge]:            https://github.com/{{cookiecutter.github_user_or_org}}/{{cookiecutter.project_slug}}/actions/workflows/linting.yml/badge.svg
+[linting-link]:             https://github.com/{{cookiecutter.github_user_or_org}}/{{cookiecutter.project_slug}}/actions/workflows/linting.yml
 [conda-badge]:              https://img.shields.io/conda/vn/conda-forge/{{cookiecutter.project_slug}}
 [conda-link]:               https://github.com/conda-forge/{{cookiecutter.project_slug}}-feedstock
 [pypi-link]:                https://pypi.org/project/{{cookiecutter.project_slug}}/
@@ -70,13 +70,13 @@ Centre for Advanced Research Computing, University College London
 We recommend installing in a project specific virtual environment created using a environment management tool such as [Mamba](https://mamba.readthedocs.io/en/latest/user_guide/mamba.html) or [Conda](https://conda.io/projects/conda/en/latest/). To install the latest development version of `{{cookiecutter.project_slug}}` using `pip` in the currently active environment run
 
 ```sh
-pip install git+https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}.git
+pip install git+https://github.com/{{cookiecutter.github_user_or_org}}/{{cookiecutter.project_slug}}.git
 ```
 
 Alternatively create a local clone of the repository with
 
 ```sh
-git clone https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}.git
+git clone https://github.com/{{cookiecutter.github_user_or_org}}/{{cookiecutter.project_slug}}.git
 ```
 
 and then install in editable mode by running

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -42,7 +42,7 @@ optional-dependencies = {dev = [
 readme = "README.md"
 requires-python = ">={{cookiecutter.min_python_version}}"
 license.file = "LICENSE.md"
-urls.homepage = "https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}"
+urls.homepage = "https://github.com/{{cookiecutter.github_user_or_org}}/{{cookiecutter.project_slug}}"
 
 [tool.coverage]
 report = {skip_covered = true, sort = "cover"}


### PR DESCRIPTION
I didn't realise that the intent of this variable was to be the username *or* organisation where the git repository is remotely located. So when I ran the cookiecutter I put in my username, then had to change it all to the org I was actually using.

Hopefully this PR makes it clearer that this variable can be a username or an organisation.