### PR TITLE
Add a [test] extra to package dependencies

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -41,7 +41,6 @@ test = [
     "pytest-cov",
 ]
 dev = [
-    "{{cookiecutter.project_slug}}[test]",
     "build",
     "mypy",
     "pre-commit",

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -30,9 +30,6 @@ dynamic = [
 keywords = [
 ]
 name = "{{cookiecutter.project_slug}}"
-readme = "README.md"
-requires-python = ">={{cookiecutter.min_python_version}}"
-license.file = "LICENSE.md"
 optional-dependencies = {dev = [
     "build",
     "mypy",
@@ -44,6 +41,9 @@ optional-dependencies = {dev = [
     "pytest",
     "pytest-cov",
 ]}
+readme = "README.md"
+requires-python = ">={{cookiecutter.min_python_version}}"
+license.file = "LICENSE.md"
 urls.homepage = "https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}"
 
 [tool.coverage]

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -30,19 +30,25 @@ dynamic = [
 keywords = [
 ]
 name = "{{cookiecutter.project_slug}}"
-optional-dependencies = {dev = [
-    "build",
-    "mypy",
-    "pre-commit",
-    "pytest",
-    "ruff",
-    "tox>=4",
-    "twine",
-]}
 readme = "README.md"
 requires-python = ">={{cookiecutter.min_python_version}}"
 license.file = "LICENSE.md"
 urls.homepage = "https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}"
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-cov",
+]
+dev = [
+    "{{cookiecutter.project_slug}}[test]",
+    "build",
+    "mypy",
+    "pre-commit",
+    "ruff",
+    "tox>=4",
+    "twine",
+]
 
 [tool.coverage]
 report = {skip_covered = true, sort = "cover"}
@@ -119,9 +125,7 @@ legacy_tox_ini = """
     [testenv]
     commands =
         pytest --cov --cov-report=xml
-    deps =
-        pytest
-        pytest-cov
+    extras = test
 
     [tox]
     env_list =

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -33,21 +33,18 @@ name = "{{cookiecutter.project_slug}}"
 readme = "README.md"
 requires-python = ">={{cookiecutter.min_python_version}}"
 license.file = "LICENSE.md"
-urls.homepage = "https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}"
-
-[project.optional-dependencies]
-test = [
-    "pytest",
-    "pytest-cov",
-]
-dev = [
+optional-dependencies = {dev = [
     "build",
     "mypy",
     "pre-commit",
     "ruff",
-    "tox>=4",
+    "tox",
     "twine",
-]
+], test = [
+    "pytest",
+    "pytest-cov",
+]}
+urls.homepage = "https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}"
 
 [tool.coverage]
 report = {skip_covered = true, sort = "cover"}

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -121,7 +121,8 @@ legacy_tox_ini = """
     [testenv]
     commands =
         pytest --cov --cov-report=xml
-    extras = test
+    extras =
+        test
 
     [tox]
     env_list =


### PR DESCRIPTION
This

- prevents dependencies being duplicated in the package requirements and the `tox` config.
- makes it easier to install `tox` (in the dev extra) without installing pytest, which isn't needed if you're just going to run tests via tox.