### PR TITLE
Add a placeholder title to all issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 description: Create a Report to Help us Improve
-title: ""
+title: "A one-line description of your problem"
 labels:
   - bug
 assignees:

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,7 +1,7 @@
 ---
 name: Documentation
 description: How Can We Improve the Documentation
-title: ""
+title: "What needs improving in the documentation?"
 labels:
   - documentation
 assignees:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 description: Suggest a Way to Improve This Project
-title: ""
+title: "Feature suggestion: What should be added?"
 labels:
   - enhancement
 assignees:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,7 +1,7 @@
 ---
 name: Question
 description: General Questions About Using the Cookiecutter Template
-title: ""
+title: "The title of your question."
 labels:
   - question
 assignees:

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,7 +1,7 @@
 ---
 name: Task
 description: A Task to be Completed
-title: ""
+title: "Task: What needs to be done?"
 labels:
   - task
 assignees:

--- a/.github/ISSUE_TEMPLATE/website.yml
+++ b/.github/ISSUE_TEMPLATE/website.yml
@@ -1,7 +1,7 @@
 ---
 name: Website
 description: How Can We Improve the Website
-title: ""
+title: "Website Improvement:"
 labels:
   - website
 assignees:

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 description: Create a Report to Help us Improve
-title: "[BUG]: "
+title: "A one-line description of your problem"
 labels:
   - bug
 assignees:

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,7 +1,7 @@
 ---
 name: Documentation
 description: How Can We Improve the Documentation
-title: "[DOCS]: "
+title: "What needs improving in the documentation?"
 labels:
   - documentation
 assignees:

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 description: Suggest a Way to Improve This Project
-title: "[FEATURE]: "
+title: "Feature suggestion: What should be added?"
 labels:
   - enhancement
 assignees:

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/question.yml
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/question.yml
@@ -1,7 +1,7 @@
 ---
 name: Question
 description: General Questions About Using {{cookiecutter.project_name}}
-title: "[QUESTION]: "
+title: "The title of your question."
 labels:
   - question
 assignees:


### PR DESCRIPTION
I was today years old when I learned this:

<img width="718" alt="Screenshot 2024-02-16 at 07 45 54" src="https://github.com/UCL-ARC/python-tooling/assets/1836192/7dd5ffc1-8c3e-4d9a-8a54-c4ccd92f1919">

---


Fixes [this problem](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#key-must-be-a-string) introduced in 
- #297 