### PR TITLE
Validate GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -59,4 +59,4 @@ body:
         - Cookiecutter version:
         - Operating system:
         - Python version:
-      render: markdown
+      render: Markdown

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,12 @@ repos:
         args:
           - --fix=lf
       - id: trailing-whitespace
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: cb934cfd6d2eea1aed7b20e4e9e6339d5952322c # 0.28.0
+    hooks:
+      # Schemas taken from https://www.schemastore.org/json/
+      - id: check-jsonschema
+        name: "Validate GitHub issue templates"
+        files: ^\.github/ISSUE_TEMPLATE/.*\.yml$
+        exclude: ^\.github/ISSUE_TEMPLATE/config\.yml$
+        args: ["--verbose", "--schemafile", "schemas/github-issue-forms.json"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
           - --fix=lf
       - id: trailing-whitespace
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: cb934cfd6d2eea1aed7b20e4e9e6339d5952322c # 0.28.0
+    rev: 0.28.0
     hooks:
       # Schemas taken from https://www.schemastore.org/json/
       - id: check-jsonschema

--- a/schemas/github-issue-forms.json
+++ b/schemas/github-issue-forms.json
@@ -1,0 +1,2377 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+
+  "$id": "https://json.schemastore.org/github-issue-forms.json",
+
+  "$comment": "https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms",
+
+  "additionalProperties": false,
+
+  "definitions": {
+    "type": {
+      "description": "A form item type\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#keys",
+
+      "type": "string",
+
+      "enum": ["checkboxes", "dropdown", "input", "markdown", "textarea"]
+    },
+
+    "id": {
+      "type": "string",
+
+      "pattern": "^[a-zA-Z0-9_-]+$",
+
+      "examples": ["SampleId"]
+    },
+
+    "validations": {
+      "title": "validation options",
+
+      "type": "object",
+
+      "properties": {
+        "required": {
+          "description": "Specify whether require a form item",
+
+          "type": "boolean",
+
+          "default": false
+        }
+      },
+
+      "additionalProperties": false
+    },
+
+    "assignee": {
+      "type": "string",
+
+      "maxLength": 39,
+
+      "pattern": "^[a-zA-Z0-9](-?[a-zA-Z0-9])*$",
+
+      "examples": ["SampleAssignee"]
+    },
+
+    "label": {
+      "type": "string",
+
+      "minLength": 1,
+
+      "examples": ["Sample label"]
+    },
+
+    "description": {
+      "type": "string",
+
+      "default": "",
+
+      "examples": ["Sample description"]
+    },
+
+    "placeholder": {
+      "type": "string",
+
+      "default": "",
+
+      "examples": ["Sample placeholder"]
+    },
+
+    "value": {
+      "type": "string",
+
+      "minLength": 1,
+
+      "examples": ["Sample value"]
+    },
+
+    "form_item": {
+      "title": "form item",
+
+      "description": "A form item\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#about-githubs-form-schema",
+
+      "type": "object",
+
+      "required": ["type"],
+
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/type"
+        }
+      },
+
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "markdown"
+              }
+            }
+          },
+
+          "then": {
+            "$comment": "For `additionalProperties` to work `type` must also be present here.",
+
+            "title": "markdown",
+
+            "description": "Markdown\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#markdown",
+
+            "type": "object",
+
+            "required": ["type", "attributes"],
+
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/type"
+              },
+
+              "attributes": {
+                "title": "markdown attributes",
+
+                "description": "Markdown attributes\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes",
+
+                "type": "object",
+
+                "required": ["value"],
+
+                "properties": {
+                  "value": {
+                    "description": "A markdown code\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes",
+
+                    "type": "string",
+
+                    "minLength": 1,
+
+                    "examples": ["Sample code"]
+                  }
+                },
+
+                "additionalProperties": false
+              }
+            },
+
+            "additionalProperties": false
+          }
+        },
+
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "textarea"
+              }
+            }
+          },
+
+          "then": {
+            "$comment": "For `additionalProperties` to work `type` must also be present here.",
+
+            "title": "textarea",
+
+            "description": "Textarea\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#textarea",
+
+            "type": "object",
+
+            "required": ["type", "attributes"],
+
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/type"
+              },
+
+              "id": {
+                "$ref": "#/definitions/id",
+
+                "description": "A textarea id\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#keys"
+              },
+
+              "attributes": {
+                "title": "textarea attributes",
+
+                "description": "Textarea attributes\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-1",
+
+                "type": "object",
+
+                "required": ["label"],
+
+                "properties": {
+                  "label": {
+                    "$ref": "#/definitions/label",
+
+                    "description": "A short textarea description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-1"
+                  },
+
+                  "description": {
+                    "$ref": "#/definitions/description",
+
+                    "description": "A long textarea description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-1"
+                  },
+
+                  "placeholder": {
+                    "$ref": "#/definitions/placeholder",
+
+                    "description": "A textarea placeholder\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-1"
+                  },
+
+                  "value": {
+                    "$ref": "#/definitions/value",
+
+                    "description": "A textarea value\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-1"
+                  },
+
+                  "render": {
+                    "description": "A textarea syntax highlighting mode\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-1",
+
+                    "type": "string",
+
+                    "enum": [
+                      "1C Enterprise",
+
+                      "4D",
+
+                      "ABAP CDS",
+
+                      "ABAP",
+
+                      "ABNF",
+
+                      "AFDKO",
+
+                      "AGS Script",
+
+                      "AIDL",
+
+                      "AL",
+
+                      "AMPL",
+
+                      "ANTLR",
+
+                      "API Blueprint",
+
+                      "APL",
+
+                      "ASL",
+
+                      "ASN.1",
+
+                      "ASP.NET",
+
+                      "ATS",
+
+                      "ActionScript",
+
+                      "Ada",
+
+                      "Alloy",
+
+                      "Alpine Abuild",
+
+                      "Altium Designer",
+
+                      "AngelScript",
+
+                      "Ant Build System",
+
+                      "ApacheConf",
+
+                      "Apex",
+
+                      "Apollo Guidance Computer",
+
+                      "AppleScript",
+
+                      "Arc",
+
+                      "AsciiDoc",
+
+                      "AspectJ",
+
+                      "Assembly",
+
+                      "Astro",
+
+                      "Asymptote",
+
+                      "Augeas",
+
+                      "AutoHotkey",
+
+                      "AutoIt",
+
+                      "AutoIt3",
+
+                      "AutoItScript",
+
+                      "Avro IDL",
+
+                      "Awk",
+
+                      "BASIC",
+
+                      "Ballerina",
+
+                      "Batchfile",
+
+                      "Beef",
+
+                      "Befunge",
+
+                      "BibTeX",
+
+                      "Bicep",
+
+                      "Bison",
+
+                      "BitBake",
+
+                      "Blade",
+
+                      "BlitzBasic",
+
+                      "BlitzMax",
+
+                      "Boo",
+
+                      "Boogie",
+
+                      "Brainfuck",
+
+                      "Brightscript",
+
+                      "Browserslist",
+
+                      "C",
+
+                      "C#",
+
+                      "C++",
+
+                      "C-ObjDump",
+
+                      "C2hs Haskell",
+
+                      "CIL",
+
+                      "CLIPS",
+
+                      "CMake",
+
+                      "COBOL",
+
+                      "CODEOWNERS",
+
+                      "COLLADA",
+
+                      "CSON",
+
+                      "CSS",
+
+                      "CSV",
+
+                      "CUE",
+
+                      "CWeb",
+
+                      "Cabal Config",
+
+                      "Cabal",
+
+                      "Cap'n Proto",
+
+                      "Carto",
+
+                      "CartoCSS",
+
+                      "Ceylon",
+
+                      "Chapel",
+
+                      "Charity",
+
+                      "ChucK",
+
+                      "Cirru",
+
+                      "Clarion",
+
+                      "Classic ASP",
+
+                      "Clean",
+
+                      "Click",
+
+                      "Clojure",
+
+                      "Closure Templates",
+
+                      "Cloud Firestore Security Rules",
+
+                      "CoNLL",
+
+                      "CoNLL-U",
+
+                      "CoNLL-X",
+
+                      "ColdFusion CFC",
+
+                      "ColdFusion",
+
+                      "Common Lisp",
+
+                      "Common Workflow Language",
+
+                      "Component Pascal",
+
+                      "Containerfile",
+
+                      "Cool",
+
+                      "Coq",
+
+                      "Cpp-ObjDump",
+
+                      "Crystal",
+
+                      "Csound Document",
+
+                      "Csound Score",
+
+                      "Csound",
+
+                      "Cuda",
+
+                      "Cue Sheet",
+
+                      "Cycript",
+
+                      "Cython",
+
+                      "D-ObjDump",
+
+                      "DIGITAL Command Language",
+
+                      "DM",
+
+                      "DTrace",
+
+                      "Dafny",
+
+                      "Darcs Patch",
+
+                      "Dart",
+
+                      "DataWeave",
+
+                      "Dhall",
+
+                      "Diff",
+
+                      "Dlang",
+
+                      "Dockerfile",
+
+                      "Dogescript",
+
+                      "Dylan",
+
+                      "E",
+
+                      "E-mail",
+
+                      "EBNF",
+
+                      "ECL",
+
+                      "ECLiPSe",
+
+                      "EJS",
+
+                      "EQ",
+
+                      "Eagle",
+
+                      "Earthly",
+
+                      "Easybuild",
+
+                      "Ecere Projects",
+
+                      "EditorConfig",
+
+                      "Eiffel",
+
+                      "Elixir",
+
+                      "Elm",
+
+                      "Emacs Lisp",
+
+                      "EmberScript",
+
+                      "Erlang",
+
+                      "F#",
+
+                      "F*",
+
+                      "FIGfont",
+
+                      "FIGlet Font",
+
+                      "FLUX",
+
+                      "Factor",
+
+                      "Fancy",
+
+                      "Fantom",
+
+                      "Faust",
+
+                      "Fennel",
+
+                      "Filebench WML",
+
+                      "Filterscript",
+
+                      "Fluent",
+
+                      "Formatted",
+
+                      "Forth",
+
+                      "Fortran Free Form",
+
+                      "Fortran",
+
+                      "FreeBasic",
+
+                      "Frege",
+
+                      "Futhark",
+
+                      "G-code",
+
+                      "GAML",
+
+                      "GAMS",
+
+                      "GAP",
+
+                      "GCC Machine Description",
+
+                      "GDB",
+
+                      "GDScript",
+
+                      "GEDCOM",
+
+                      "GLSL",
+
+                      "GN",
+
+                      "Game Maker Language",
+
+                      "Gemfile.lock",
+
+                      "Genie",
+
+                      "Genshi",
+
+                      "Gentoo Eclass",
+
+                      "Gerber Image",
+
+                      "Gettext Catalog",
+
+                      "Gherkin",
+
+                      "Git Config",
+
+                      "Glyph Bitmap Distribution Format",
+
+                      "Glyph",
+
+                      "Gnuplot",
+
+                      "Go Checksums",
+
+                      "Go Module",
+
+                      "Go",
+
+                      "Golo",
+
+                      "Gosu",
+
+                      "Grace",
+
+                      "Gradle",
+
+                      "Grammatical Framework",
+
+                      "Graph Modeling Language",
+
+                      "GraphQL",
+
+                      "Graphviz (DOT)",
+
+                      "Groovy Server Pages",
+
+                      "Groovy",
+
+                      "HAProxy",
+
+                      "HCL",
+
+                      "HTML",
+
+                      "HTML+ECR",
+
+                      "HTML+EEX",
+
+                      "HTML+ERB",
+
+                      "HTML+PHP",
+
+                      "HTML+Razor",
+
+                      "HTTP",
+
+                      "HXML",
+
+                      "Hack",
+
+                      "Haml",
+
+                      "Handlebars",
+
+                      "Harbour",
+
+                      "HashiCorp Configuration Language",
+
+                      "Haskell",
+
+                      "Haxe",
+
+                      "HiveQL",
+
+                      "HolyC",
+
+                      "Hy",
+
+                      "IDL",
+
+                      "IGOR Pro",
+
+                      "IPython Notebook",
+
+                      "Idris",
+
+                      "Ignore List",
+
+                      "ImageJ Macro",
+
+                      "Inform 7",
+
+                      "Io",
+
+                      "Ioke",
+
+                      "Isabelle ROOT",
+
+                      "Isabelle",
+
+                      "J",
+
+                      "JAR Manifest",
+
+                      "JFlex",
+
+                      "JSON with Comments",
+
+                      "JSON",
+
+                      "JSON5",
+
+                      "JSONLD",
+
+                      "JSONiq",
+
+                      "Jasmin",
+
+                      "Java Properties",
+
+                      "Java Server Pages",
+
+                      "Java",
+
+                      "JavaScript",
+
+                      "JavaScript+ERB",
+
+                      "Jest Snapshot",
+
+                      "Jinja",
+
+                      "Jison Lex",
+
+                      "Jison",
+
+                      "Jolie",
+
+                      "Jsonnet",
+
+                      "Julia",
+
+                      "Jupyter Notebook",
+
+                      "Kaitai Struct",
+
+                      "KakouneScript",
+
+                      "KiCad Layout",
+
+                      "KiCad Legacy Layout",
+
+                      "KiCad Schematic",
+
+                      "Kit",
+
+                      "Kotlin",
+
+                      "Kusto",
+
+                      "LFE",
+
+                      "LLVM",
+
+                      "LOLCODE",
+
+                      "LSL",
+
+                      "LTspice Symbol",
+
+                      "LabVIEW",
+
+                      "Lark",
+
+                      "Lasso",
+
+                      "Lean",
+
+                      "Less",
+
+                      "Lex",
+
+                      "LilyPond",
+
+                      "Limbo",
+
+                      "Linker Script",
+
+                      "Linux Kernel Module",
+
+                      "Liquid",
+
+                      "Literate Agda",
+
+                      "Literate CoffeeScript",
+
+                      "Literate Haskell",
+
+                      "LiveScript",
+
+                      "Logos",
+
+                      "Logtalk",
+
+                      "LookML",
+
+                      "LoomScript",
+
+                      "Lua",
+
+                      "M",
+
+                      "M4",
+
+                      "M4Sugar",
+
+                      "MATLAB",
+
+                      "MAXScript",
+
+                      "MLIR",
+
+                      "MQL4",
+
+                      "MQL5",
+
+                      "MTML",
+
+                      "MUF",
+
+                      "Macaulay2",
+
+                      "Makefile",
+
+                      "Mako",
+
+                      "Markdown",
+
+                      "Marko",
+
+                      "Mathematica",
+
+                      "Max",
+
+                      "Mercury",
+
+                      "Meson",
+
+                      "Metal",
+
+                      "Microsoft Developer Studio Project",
+
+                      "Microsoft Visual Studio Solution",
+
+                      "MiniD",
+
+                      "Mirah",
+
+                      "Modelica",
+
+                      "Modula-2",
+
+                      "Modula-3",
+
+                      "Module Management System",
+
+                      "Monkey",
+
+                      "Moocode",
+
+                      "MoonScript",
+
+                      "Motoko",
+
+                      "Motorola 68K Assembly",
+
+                      "Muse",
+
+                      "Myghty",
+
+                      "NASL",
+
+                      "NCL",
+
+                      "NEON",
+
+                      "NPM Config",
+
+                      "NSIS",
+
+                      "NWScript",
+
+                      "Nearley",
+
+                      "Nemerle",
+
+                      "NeoSnippet",
+
+                      "NetLinx",
+
+                      "NetLinx+ERB",
+
+                      "NetLogo",
+
+                      "NewLisp",
+
+                      "Nextflow",
+
+                      "Nginx",
+
+                      "Ninja",
+
+                      "Nit",
+
+                      "Nix",
+
+                      "NumPy",
+
+                      "Nunjucks",
+
+                      "ObjDump",
+
+                      "Object Data Instance Notation",
+
+                      "ObjectScript",
+
+                      "Objective-C",
+
+                      "Objective-C++",
+
+                      "Objective-J",
+
+                      "Odin",
+
+                      "Omgrofl",
+
+                      "Opa",
+
+                      "Opal",
+
+                      "Open Policy Agent",
+
+                      "OpenCL",
+
+                      "OpenEdge ABL",
+
+                      "OpenQASM",
+
+                      "OpenRC runscript",
+
+                      "OpenSCAD",
+
+                      "OpenStep Property List",
+
+                      "OpenType Feature File",
+
+                      "Org",
+
+                      "Ox",
+
+                      "Oxygene",
+
+                      "Oz",
+
+                      "P4",
+
+                      "PEG.js",
+
+                      "PHP",
+
+                      "PLpgSQL",
+
+                      "POV-Ray SDL",
+
+                      "Pan",
+
+                      "Papyrus",
+
+                      "Parrot Assembly",
+
+                      "Parrot Internal Representation",
+
+                      "Parrot",
+
+                      "Pascal",
+
+                      "Pawn",
+
+                      "Pep8",
+
+                      "Perl",
+
+                      "Pickle",
+
+                      "PicoLisp",
+
+                      "PigLatin",
+
+                      "Pike",
+
+                      "PlantUML",
+
+                      "Pod 6",
+
+                      "Pod",
+
+                      "PogoScript",
+
+                      "Pony",
+
+                      "PostCSS",
+
+                      "PostScript",
+
+                      "PowerShell",
+
+                      "Prisma",
+
+                      "Processing",
+
+                      "Proguard",
+
+                      "Prolog",
+
+                      "Promela",
+
+                      "Propeller Spin",
+
+                      "Protocol Buffer",
+
+                      "Protocol Buffers",
+
+                      "Public Key",
+
+                      "Pug",
+
+                      "Puppet",
+
+                      "Pure Data",
+
+                      "PureBasic",
+
+                      "PureScript",
+
+                      "Python",
+
+                      "Q#",
+
+                      "QMake",
+
+                      "Qt Script",
+
+                      "Quake",
+
+                      "R",
+
+                      "RAML",
+
+                      "RDoc",
+
+                      "REALbasic",
+
+                      "REXX",
+
+                      "RMarkdown",
+
+                      "RPC",
+
+                      "RPM Spec",
+
+                      "Racket",
+
+                      "Ragel",
+
+                      "Raw token data",
+
+                      "ReScript",
+
+                      "Readline Config",
+
+                      "Reason",
+
+                      "Rebol",
+
+                      "Record Jar",
+
+                      "Red",
+
+                      "Redirect Rules",
+
+                      "Regular Expression",
+
+                      "RenderScript",
+
+                      "Rich Text Format",
+
+                      "Ring",
+
+                      "Riot",
+
+                      "RobotFramework",
+
+                      "Roff",
+
+                      "Rouge",
+
+                      "Rscript",
+
+                      "Ruby",
+
+                      "Rust",
+
+                      "SAS",
+
+                      "SCSS",
+
+                      "SELinux Kernel Policy Language",
+
+                      "SELinux Policy",
+
+                      "SMT",
+
+                      "SPARQL",
+
+                      "SQF",
+
+                      "SQL",
+
+                      "SQLPL",
+
+                      "SRecode Template",
+
+                      "SSH Config",
+
+                      "STON",
+
+                      "SVG",
+
+                      "SWIG",
+
+                      "Sage",
+
+                      "SaltStack",
+
+                      "Sass",
+
+                      "Scala",
+
+                      "Scaml",
+
+                      "Scheme",
+
+                      "Scilab",
+
+                      "Self",
+
+                      "ShaderLab",
+
+                      "Shell",
+
+                      "ShellCheck Config",
+
+                      "Sieve",
+
+                      "Singularity",
+
+                      "Slash",
+
+                      "Slice",
+
+                      "Slim",
+
+                      "SmPL",
+
+                      "Smalltalk",
+
+                      "SnipMate",
+
+                      "Solidity",
+
+                      "Soong",
+
+                      "SourcePawn",
+
+                      "Spline Font Database",
+
+                      "Squirrel",
+
+                      "Stan",
+
+                      "Standard ML",
+
+                      "Starlark",
+
+                      "StringTemplate",
+
+                      "Stylus",
+
+                      "SubRip Text",
+
+                      "SugarSS",
+
+                      "SuperCollider",
+
+                      "Svelte",
+
+                      "Swift",
+
+                      "SystemVerilog",
+
+                      "TI Program",
+
+                      "TLA",
+
+                      "TOML",
+
+                      "TSQL",
+
+                      "TSV",
+
+                      "TSX",
+
+                      "TXL",
+
+                      "Tcl",
+
+                      "Tcsh",
+
+                      "TeX",
+
+                      "Tea",
+
+                      "Terra",
+
+                      "Texinfo",
+
+                      "Text",
+
+                      "TextMate Properties",
+
+                      "Textile",
+
+                      "Thrift",
+
+                      "Turing",
+
+                      "Turtle",
+
+                      "Twig",
+
+                      "Type Language",
+
+                      "TypeScript",
+
+                      "UltiSnip",
+
+                      "UltiSnips",
+
+                      "Unified Parallel C",
+
+                      "Unity3D Asset",
+
+                      "Unix Assembly",
+
+                      "Uno",
+
+                      "UnrealScript",
+
+                      "Ur",
+
+                      "Ur/Web",
+
+                      "UrWeb",
+
+                      "V",
+
+                      "VBA",
+
+                      "VCL",
+
+                      "VHDL",
+
+                      "Vala",
+
+                      "Valve Data Format",
+
+                      "Verilog",
+
+                      "Vim Help File",
+
+                      "Vim Script",
+
+                      "Vim Snippet",
+
+                      "Visual Basic .NET",
+
+                      "Vue",
+
+                      "Wavefront Material",
+
+                      "Wavefront Object",
+
+                      "Web Ontology Language",
+
+                      "WebAssembly",
+
+                      "WebVTT",
+
+                      "Wget Config",
+
+                      "Wikitext",
+
+                      "Windows Registry Entries",
+
+                      "Wollok",
+
+                      "World of Warcraft Addon Data",
+
+                      "X BitMap",
+
+                      "X Font Directory Index",
+
+                      "X PixMap",
+
+                      "X10",
+
+                      "XC",
+
+                      "XCompose",
+
+                      "XML Property List",
+
+                      "XML",
+
+                      "XPages",
+
+                      "XProc",
+
+                      "XQuery",
+
+                      "XS",
+
+                      "XSLT",
+
+                      "Xojo",
+
+                      "Xonsh",
+
+                      "Xtend",
+
+                      "YAML",
+
+                      "YANG",
+
+                      "YARA",
+
+                      "YASnippet",
+
+                      "Yacc",
+
+                      "ZAP",
+
+                      "ZIL",
+
+                      "Zeek",
+
+                      "ZenScript",
+
+                      "Zephir",
+
+                      "Zig",
+
+                      "Zimpl",
+
+                      "abl",
+
+                      "abuild",
+
+                      "acfm",
+
+                      "aconf",
+
+                      "actionscript 3",
+
+                      "actionscript3",
+
+                      "ada2005",
+
+                      "ada95",
+
+                      "adobe composite font metrics",
+
+                      "adobe multiple font metrics",
+
+                      "advpl",
+
+                      "ags",
+
+                      "ahk",
+
+                      "altium",
+
+                      "amfm",
+
+                      "amusewiki",
+
+                      "apache",
+
+                      "apkbuild",
+
+                      "arexx",
+
+                      "as3",
+
+                      "asm",
+
+                      "asp",
+
+                      "aspx",
+
+                      "aspx-vb",
+
+                      "ats2",
+
+                      "au3",
+
+                      "autoconf",
+
+                      "b3d",
+
+                      "bash session",
+
+                      "bash",
+
+                      "bat",
+
+                      "batch",
+
+                      "bazel",
+
+                      "blitz3d",
+
+                      "blitzplus",
+
+                      "bmax",
+
+                      "bplus",
+
+                      "bro",
+
+                      "bsdmake",
+
+                      "byond",
+
+                      "bzl",
+
+                      "c++-objdump",
+
+                      "c2hs",
+
+                      "cURL Config",
+
+                      "cake",
+
+                      "cakescript",
+
+                      "cfc",
+
+                      "cfm",
+
+                      "cfml",
+
+                      "chpl",
+
+                      "clipper",
+
+                      "coccinelle",
+
+                      "coffee",
+
+                      "coffee-script",
+
+                      "coldfusion html",
+
+                      "console",
+
+                      "cperl",
+
+                      "cpp",
+
+                      "csharp",
+
+                      "csound-csd",
+
+                      "csound-orc",
+
+                      "csound-sco",
+
+                      "cucumber",
+
+                      "curlrc",
+
+                      "cwl",
+
+                      "dcl",
+
+                      "delphi",
+
+                      "desktop",
+
+                      "dircolors",
+
+                      "django",
+
+                      "dosbatch",
+
+                      "dosini",
+
+                      "dpatch",
+
+                      "dtrace-script",
+
+                      "eC",
+
+                      "ecr",
+
+                      "editor-config",
+
+                      "edn",
+
+                      "eeschema schematic",
+
+                      "eex",
+
+                      "elisp",
+
+                      "emacs muse",
+
+                      "emacs",
+
+                      "email",
+
+                      "eml",
+
+                      "erb",
+
+                      "fb",
+
+                      "fish",
+
+                      "flex",
+
+                      "foxpro",
+
+                      "fsharp",
+
+                      "fstar",
+
+                      "ftl",
+
+                      "fundamental",
+
+                      "gf",
+
+                      "git-ignore",
+
+                      "gitattributes",
+
+                      "gitconfig",
+
+                      "gitignore",
+
+                      "gitmodules",
+
+                      "go mod",
+
+                      "go sum",
+
+                      "go.mod",
+
+                      "go.sum",
+
+                      "golang",
+
+                      "groff",
+
+                      "gsp",
+
+                      "hbs",
+
+                      "heex",
+
+                      "help",
+
+                      "html+django",
+
+                      "html+jinja",
+
+                      "html+ruby",
+
+                      "htmlbars",
+
+                      "htmldjango",
+
+                      "hylang",
+
+                      "i7",
+
+                      "ignore",
+
+                      "igor",
+
+                      "igorpro",
+
+                      "ijm",
+
+                      "inc",
+
+                      "inform7",
+
+                      "inputrc",
+
+                      "irc logs",
+
+                      "irc",
+
+                      "java server page",
+
+                      "jq",
+
+                      "jruby",
+
+                      "js",
+
+                      "jsonc",
+
+                      "jsp",
+
+                      "kak",
+
+                      "kakscript",
+
+                      "keyvalues",
+
+                      "ksy",
+
+                      "lassoscript",
+
+                      "latex",
+
+                      "leex",
+
+                      "lhaskell",
+
+                      "lhs",
+
+                      "lisp",
+
+                      "litcoffee",
+
+                      "live-script",
+
+                      "ls",
+
+                      "m2",
+
+                      "m68k",
+
+                      "mIRC Script",
+
+                      "macruby",
+
+                      "mail",
+
+                      "make",
+
+                      "man page",
+
+                      "man",
+
+                      "man-page",
+
+                      "manpage",
+
+                      "markojs",
+
+                      "max/msp",
+
+                      "maxmsp",
+
+                      "mbox",
+
+                      "mcfunction",
+
+                      "mdoc",
+
+                      "mediawiki",
+
+                      "mf",
+
+                      "mma",
+
+                      "mumps",
+
+                      "mupad",
+
+                      "nanorc",
+
+                      "nasm",
+
+                      "ne-on",
+
+                      "nesC",
+
+                      "nette object notation",
+
+                      "nginx configuration file",
+
+                      "nixos",
+
+                      "njk",
+
+                      "node",
+
+                      "npmrc",
+
+                      "nroff",
+
+                      "nush",
+
+                      "nvim",
+
+                      "obj-c",
+
+                      "obj-c++",
+
+                      "obj-j",
+
+                      "objc",
+
+                      "objc++",
+
+                      "objectivec",
+
+                      "objectivec++",
+
+                      "objectivej",
+
+                      "objectpascal",
+
+                      "objj",
+
+                      "octave",
+
+                      "odin-lang",
+
+                      "odinlang",
+
+                      "oncrpc",
+
+                      "ooc",
+
+                      "openedge",
+
+                      "openrc",
+
+                      "osascript",
+
+                      "pandoc",
+
+                      "pasm",
+
+                      "pcbnew",
+
+                      "perl-6",
+
+                      "perl6",
+
+                      "pir",
+
+                      "plain text",
+
+                      "posh",
+
+                      "postscr",
+
+                      "pot",
+
+                      "pov-ray",
+
+                      "povray",
+
+                      "progress",
+
+                      "protobuf",
+
+                      "pwsh",
+
+                      "pycon",
+
+                      "pyrex",
+
+                      "python3",
+
+                      "q",
+
+                      "ql",
+
+                      "qsharp",
+
+                      "ragel-rb",
+
+                      "ragel-ruby",
+
+                      "rake",
+
+                      "raw",
+
+                      "razor",
+
+                      "rb",
+
+                      "rbx",
+
+                      "reStructuredText",
+
+                      "readline",
+
+                      "red/system",
+
+                      "redirects",
+
+                      "regex",
+
+                      "regexp",
+
+                      "renpy",
+
+                      "rhtml",
+
+                      "robots txt",
+
+                      "robots",
+
+                      "robots.txt",
+
+                      "rpcgen",
+
+                      "rs",
+
+                      "rs-274x",
+
+                      "rss",
+
+                      "rst",
+
+                      "rusthon",
+
+                      "salt",
+
+                      "saltstate",
+
+                      "sed",
+
+                      "sepolicy",
+
+                      "sh",
+
+                      "shell-script",
+
+                      "shellcheckrc",
+
+                      "sml",
+
+                      "snippet",
+
+                      "sourcemod",
+
+                      "soy",
+
+                      "specfile",
+
+                      "splus",
+
+                      "squeak",
+
+                      "terraform",
+
+                      "tl",
+
+                      "tm-properties",
+
+                      "troff",
+
+                      "ts",
+
+                      "udiff",
+
+                      "vb .net",
+
+                      "vb.net",
+
+                      "vb6",
+
+                      "vbnet",
+
+                      "vdf",
+
+                      "vim",
+
+                      "vimhelp",
+
+                      "viml",
+
+                      "visual basic 6",
+
+                      "visual basic for applications",
+
+                      "visual basic",
+
+                      "vlang",
+
+                      "wasm",
+
+                      "wast",
+
+                      "wdl",
+
+                      "wgetrc",
+
+                      "wiki",
+
+                      "winbatch",
+
+                      "wisp",
+
+                      "wl",
+
+                      "wolfram lang",
+
+                      "wolfram language",
+
+                      "wolfram",
+
+                      "wsdl",
+
+                      "xBase",
+
+                      "xbm",
+
+                      "xdr",
+
+                      "xhtml",
+
+                      "xml+genshi",
+
+                      "xml+kid",
+
+                      "xpm",
+
+                      "xsd",
+
+                      "xsl",
+
+                      "xten",
+
+                      "yas",
+
+                      "yml",
+
+                      "zsh"
+                    ]
+                  }
+                },
+
+                "additionalProperties": false
+              },
+
+              "validations": {
+                "$ref": "#/definitions/validations",
+
+                "title": "textarea validations",
+
+                "description": "Textarea validations\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#validations"
+              }
+            },
+
+            "additionalProperties": false
+          }
+        },
+
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "input"
+              }
+            }
+          },
+
+          "then": {
+            "$comment": "For `additionalProperties` to work `type` must also be present here.",
+
+            "title": "input",
+
+            "description": "Input\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#input",
+
+            "type": "object",
+
+            "required": ["type", "attributes"],
+
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/type"
+              },
+
+              "id": {
+                "$ref": "#/definitions/id",
+
+                "description": "An input id\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#keys"
+              },
+
+              "attributes": {
+                "title": "input attributes",
+
+                "description": "Input attributes\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-2",
+
+                "type": "object",
+
+                "required": ["label"],
+
+                "properties": {
+                  "label": {
+                    "$ref": "#/definitions/label",
+
+                    "description": "A short input description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-2"
+                  },
+
+                  "description": {
+                    "$ref": "#/definitions/description",
+
+                    "description": "A long input description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-2"
+                  },
+
+                  "placeholder": {
+                    "$ref": "#/definitions/placeholder",
+
+                    "description": "An input placeholder\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-2"
+                  },
+
+                  "value": {
+                    "$ref": "#/definitions/value",
+
+                    "description": "An input value\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-2"
+                  }
+                },
+
+                "additionalProperties": false
+              },
+
+              "validations": {
+                "$ref": "#/definitions/validations",
+
+                "title": "input validations",
+
+                "description": "Input validations\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#validations-1"
+              }
+            },
+
+            "additionalProperties": false
+          }
+        },
+
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "dropdown"
+              }
+            }
+          },
+
+          "then": {
+            "$comment": "For `additionalProperties` to work `type` must also be present here.",
+
+            "title": "dropdown",
+
+            "description": "dropdown\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#dropdown",
+
+            "type": "object",
+
+            "required": ["type", "attributes"],
+
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/type"
+              },
+
+              "id": {
+                "$ref": "#/definitions/id",
+
+                "description": "A dropdown id\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#keys"
+              },
+
+              "attributes": {
+                "title": "dropdown attributes",
+
+                "description": "Dropdown attributes\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-3",
+
+                "type": "object",
+
+                "required": ["label", "options"],
+
+                "properties": {
+                  "label": {
+                    "$ref": "#/definitions/label",
+
+                    "description": "A short dropdown description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-3"
+                  },
+
+                  "description": {
+                    "$ref": "#/definitions/description",
+
+                    "description": "A long dropdown description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-3"
+                  },
+
+                  "multiple": {
+                    "description": "Specify whether allow a multiple choices\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-3",
+
+                    "type": "boolean",
+
+                    "default": false
+                  },
+
+                  "options": {
+                    "description": "Dropdown choices\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-3",
+
+                    "type": "array",
+
+                    "minItems": 1,
+
+                    "uniqueItems": true,
+
+                    "items": {
+                      "type": "string",
+
+                      "minLength": 1,
+
+                      "examples": ["Sample choice"]
+                    }
+                  },
+
+                  "default": {
+                    "description": "Index of the default option\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-3",
+
+                    "type": "integer",
+
+                    "examples": [0]
+                  }
+                },
+
+                "additionalProperties": false
+              },
+
+              "validations": {
+                "$ref": "#/definitions/validations",
+
+                "title": "dropdown validations",
+
+                "description": "Dropdown validations\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#validations-2"
+              }
+            },
+
+            "additionalProperties": false
+          }
+        },
+
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "checkboxes"
+              }
+            }
+          },
+
+          "then": {
+            "$comment": "For `additionalProperties` to work `type` must also be present here.",
+
+            "title": "checkboxes",
+
+            "description": "Checkboxes\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#checkboxes",
+
+            "type": "object",
+
+            "required": ["type", "attributes"],
+
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/type"
+              },
+
+              "id": {
+                "$ref": "#/definitions/id",
+
+                "description": "Checkbox list id\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#keys"
+              },
+
+              "attributes": {
+                "title": "checkbox list attributes",
+
+                "description": "Checkbox list attributes\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-4",
+
+                "type": "object",
+
+                "required": ["label", "options"],
+
+                "properties": {
+                  "label": {
+                    "$ref": "#/definitions/label",
+
+                    "description": "A short checkbox list description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-4"
+                  },
+
+                  "description": {
+                    "$ref": "#/definitions/description",
+
+                    "description": "A long checkbox list description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-4"
+                  },
+
+                  "options": {
+                    "description": "Checkbox list choices\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-4",
+
+                    "type": "array",
+
+                    "minItems": 1,
+
+                    "items": {
+                      "title": "checkbox list choice",
+
+                      "description": "Checkbox list choice\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-4",
+
+                      "type": "object",
+
+                      "required": ["label"],
+
+                      "properties": {
+                        "label": {
+                          "description": "A short checkbox list choice description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-4",
+
+                          "type": "string",
+
+                          "minLength": 1,
+
+                          "examples": ["Sample label"]
+                        },
+
+                        "required": {
+                          "description": "Specify whether a choice is required\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-4",
+
+                          "type": "boolean",
+
+                          "default": false
+                        }
+                      },
+
+                      "additionalProperties": false
+                    }
+                  }
+                },
+
+                "additionalProperties": false
+              }
+            },
+
+            "additionalProperties": false
+          }
+        }
+      ]
+    }
+  },
+
+  "properties": {
+    "name": {
+      "description": "An issue template name\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax",
+
+      "type": "string",
+
+      "minLength": 1,
+
+      "examples": ["Sample name"]
+    },
+
+    "description": {
+      "description": "An issue template description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax",
+
+      "type": "string",
+
+      "minLength": 1,
+
+      "examples": ["Sample description"]
+    },
+
+    "body": {
+      "description": "An issue template body\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax",
+
+      "type": "array",
+
+      "minItems": 1,
+
+      "items": {
+        "$ref": "#/definitions/form_item"
+      }
+    },
+
+    "assignees": {
+      "description": "An issue template assignees\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax",
+
+      "oneOf": [
+        {
+          "$ref": "#/definitions/assignee"
+        },
+
+        {
+          "type": "array",
+
+          "minItems": 1,
+
+          "uniqueItems": true,
+
+          "items": {
+            "$ref": "#/definitions/assignee"
+          }
+        }
+      ]
+    },
+
+    "labels": {
+      "description": "An issue template labels\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax",
+
+      "type": "array",
+
+      "minItems": 1,
+
+      "uniqueItems": true,
+
+      "items": {
+        "type": "string",
+
+        "minLength": 1,
+
+        "examples": [
+          "Sample label",
+
+          "bug",
+
+          "documentation",
+
+          "duplicate",
+
+          "enhancement",
+
+          "good first issue",
+
+          "help wanted",
+
+          "invalid",
+
+          "question",
+
+          "wontfix"
+        ]
+      }
+    },
+
+    "title": {
+      "description": "An issue template title\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax",
+
+      "type": "string",
+
+      "minLength": 1,
+
+      "examples": ["Sample title", "Bug: ", "Feature: "]
+    }
+  },
+
+  "required": ["name", "description", "body"],
+
+  "title": "GitHub issue forms config file schema",
+
+  "type": "object"
+}

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,7 +25,7 @@ body:
         import {{cookiecutter.package_name}}
 
         ...
-      render: python
+      render: Python
     validations:
       required: true
   - id: expected

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,4 +63,4 @@ body:
       value: |-
         - Python version:
         - Operating system:
-      render: markdown
+      render: Markdown

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -32,3 +32,12 @@ repos:
         args:
           - --fix=lf
       - id: trailing-whitespace
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: cb934cfd6d2eea1aed7b20e4e9e6339d5952322c # 0.28.0
+    hooks:
+      # Schemas taken from https://www.schemastore.org/json/
+      - id: check-jsonschema
+        name: "Validate GitHub issue templates"
+        files: ^\.github/ISSUE_TEMPLATE/.*\.yml$
+        exclude: ^\.github/ISSUE_TEMPLATE/config\.yml$
+        args: ["--verbose", "--schemafile", "schemas/github-issue-forms.json"]

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
           - --fix=lf
       - id: trailing-whitespace
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: cb934cfd6d2eea1aed7b20e4e9e6339d5952322c # 0.28.0
+    rev: 0.28.0
     hooks:
       # Schemas taken from https://www.schemastore.org/json/
       - id: check-jsonschema

--- a/{{cookiecutter.project_slug}}/schemas/github-issue-forms.json
+++ b/{{cookiecutter.project_slug}}/schemas/github-issue-forms.json
@@ -1,0 +1,2377 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+
+  "$id": "https://json.schemastore.org/github-issue-forms.json",
+
+  "$comment": "https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms",
+
+  "additionalProperties": false,
+
+  "definitions": {
+    "type": {
+      "description": "A form item type\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#keys",
+
+      "type": "string",
+
+      "enum": ["checkboxes", "dropdown", "input", "markdown", "textarea"]
+    },
+
+    "id": {
+      "type": "string",
+
+      "pattern": "^[a-zA-Z0-9_-]+$",
+
+      "examples": ["SampleId"]
+    },
+
+    "validations": {
+      "title": "validation options",
+
+      "type": "object",
+
+      "properties": {
+        "required": {
+          "description": "Specify whether require a form item",
+
+          "type": "boolean",
+
+          "default": false
+        }
+      },
+
+      "additionalProperties": false
+    },
+
+    "assignee": {
+      "type": "string",
+
+      "maxLength": 39,
+
+      "pattern": "^[a-zA-Z0-9](-?[a-zA-Z0-9])*$",
+
+      "examples": ["SampleAssignee"]
+    },
+
+    "label": {
+      "type": "string",
+
+      "minLength": 1,
+
+      "examples": ["Sample label"]
+    },
+
+    "description": {
+      "type": "string",
+
+      "default": "",
+
+      "examples": ["Sample description"]
+    },
+
+    "placeholder": {
+      "type": "string",
+
+      "default": "",
+
+      "examples": ["Sample placeholder"]
+    },
+
+    "value": {
+      "type": "string",
+
+      "minLength": 1,
+
+      "examples": ["Sample value"]
+    },
+
+    "form_item": {
+      "title": "form item",
+
+      "description": "A form item\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#about-githubs-form-schema",
+
+      "type": "object",
+
+      "required": ["type"],
+
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/type"
+        }
+      },
+
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "markdown"
+              }
+            }
+          },
+
+          "then": {
+            "$comment": "For `additionalProperties` to work `type` must also be present here.",
+
+            "title": "markdown",
+
+            "description": "Markdown\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#markdown",
+
+            "type": "object",
+
+            "required": ["type", "attributes"],
+
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/type"
+              },
+
+              "attributes": {
+                "title": "markdown attributes",
+
+                "description": "Markdown attributes\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes",
+
+                "type": "object",
+
+                "required": ["value"],
+
+                "properties": {
+                  "value": {
+                    "description": "A markdown code\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes",
+
+                    "type": "string",
+
+                    "minLength": 1,
+
+                    "examples": ["Sample code"]
+                  }
+                },
+
+                "additionalProperties": false
+              }
+            },
+
+            "additionalProperties": false
+          }
+        },
+
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "textarea"
+              }
+            }
+          },
+
+          "then": {
+            "$comment": "For `additionalProperties` to work `type` must also be present here.",
+
+            "title": "textarea",
+
+            "description": "Textarea\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#textarea",
+
+            "type": "object",
+
+            "required": ["type", "attributes"],
+
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/type"
+              },
+
+              "id": {
+                "$ref": "#/definitions/id",
+
+                "description": "A textarea id\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#keys"
+              },
+
+              "attributes": {
+                "title": "textarea attributes",
+
+                "description": "Textarea attributes\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-1",
+
+                "type": "object",
+
+                "required": ["label"],
+
+                "properties": {
+                  "label": {
+                    "$ref": "#/definitions/label",
+
+                    "description": "A short textarea description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-1"
+                  },
+
+                  "description": {
+                    "$ref": "#/definitions/description",
+
+                    "description": "A long textarea description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-1"
+                  },
+
+                  "placeholder": {
+                    "$ref": "#/definitions/placeholder",
+
+                    "description": "A textarea placeholder\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-1"
+                  },
+
+                  "value": {
+                    "$ref": "#/definitions/value",
+
+                    "description": "A textarea value\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-1"
+                  },
+
+                  "render": {
+                    "description": "A textarea syntax highlighting mode\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-1",
+
+                    "type": "string",
+
+                    "enum": [
+                      "1C Enterprise",
+
+                      "4D",
+
+                      "ABAP CDS",
+
+                      "ABAP",
+
+                      "ABNF",
+
+                      "AFDKO",
+
+                      "AGS Script",
+
+                      "AIDL",
+
+                      "AL",
+
+                      "AMPL",
+
+                      "ANTLR",
+
+                      "API Blueprint",
+
+                      "APL",
+
+                      "ASL",
+
+                      "ASN.1",
+
+                      "ASP.NET",
+
+                      "ATS",
+
+                      "ActionScript",
+
+                      "Ada",
+
+                      "Alloy",
+
+                      "Alpine Abuild",
+
+                      "Altium Designer",
+
+                      "AngelScript",
+
+                      "Ant Build System",
+
+                      "ApacheConf",
+
+                      "Apex",
+
+                      "Apollo Guidance Computer",
+
+                      "AppleScript",
+
+                      "Arc",
+
+                      "AsciiDoc",
+
+                      "AspectJ",
+
+                      "Assembly",
+
+                      "Astro",
+
+                      "Asymptote",
+
+                      "Augeas",
+
+                      "AutoHotkey",
+
+                      "AutoIt",
+
+                      "AutoIt3",
+
+                      "AutoItScript",
+
+                      "Avro IDL",
+
+                      "Awk",
+
+                      "BASIC",
+
+                      "Ballerina",
+
+                      "Batchfile",
+
+                      "Beef",
+
+                      "Befunge",
+
+                      "BibTeX",
+
+                      "Bicep",
+
+                      "Bison",
+
+                      "BitBake",
+
+                      "Blade",
+
+                      "BlitzBasic",
+
+                      "BlitzMax",
+
+                      "Boo",
+
+                      "Boogie",
+
+                      "Brainfuck",
+
+                      "Brightscript",
+
+                      "Browserslist",
+
+                      "C",
+
+                      "C#",
+
+                      "C++",
+
+                      "C-ObjDump",
+
+                      "C2hs Haskell",
+
+                      "CIL",
+
+                      "CLIPS",
+
+                      "CMake",
+
+                      "COBOL",
+
+                      "CODEOWNERS",
+
+                      "COLLADA",
+
+                      "CSON",
+
+                      "CSS",
+
+                      "CSV",
+
+                      "CUE",
+
+                      "CWeb",
+
+                      "Cabal Config",
+
+                      "Cabal",
+
+                      "Cap'n Proto",
+
+                      "Carto",
+
+                      "CartoCSS",
+
+                      "Ceylon",
+
+                      "Chapel",
+
+                      "Charity",
+
+                      "ChucK",
+
+                      "Cirru",
+
+                      "Clarion",
+
+                      "Classic ASP",
+
+                      "Clean",
+
+                      "Click",
+
+                      "Clojure",
+
+                      "Closure Templates",
+
+                      "Cloud Firestore Security Rules",
+
+                      "CoNLL",
+
+                      "CoNLL-U",
+
+                      "CoNLL-X",
+
+                      "ColdFusion CFC",
+
+                      "ColdFusion",
+
+                      "Common Lisp",
+
+                      "Common Workflow Language",
+
+                      "Component Pascal",
+
+                      "Containerfile",
+
+                      "Cool",
+
+                      "Coq",
+
+                      "Cpp-ObjDump",
+
+                      "Crystal",
+
+                      "Csound Document",
+
+                      "Csound Score",
+
+                      "Csound",
+
+                      "Cuda",
+
+                      "Cue Sheet",
+
+                      "Cycript",
+
+                      "Cython",
+
+                      "D-ObjDump",
+
+                      "DIGITAL Command Language",
+
+                      "DM",
+
+                      "DTrace",
+
+                      "Dafny",
+
+                      "Darcs Patch",
+
+                      "Dart",
+
+                      "DataWeave",
+
+                      "Dhall",
+
+                      "Diff",
+
+                      "Dlang",
+
+                      "Dockerfile",
+
+                      "Dogescript",
+
+                      "Dylan",
+
+                      "E",
+
+                      "E-mail",
+
+                      "EBNF",
+
+                      "ECL",
+
+                      "ECLiPSe",
+
+                      "EJS",
+
+                      "EQ",
+
+                      "Eagle",
+
+                      "Earthly",
+
+                      "Easybuild",
+
+                      "Ecere Projects",
+
+                      "EditorConfig",
+
+                      "Eiffel",
+
+                      "Elixir",
+
+                      "Elm",
+
+                      "Emacs Lisp",
+
+                      "EmberScript",
+
+                      "Erlang",
+
+                      "F#",
+
+                      "F*",
+
+                      "FIGfont",
+
+                      "FIGlet Font",
+
+                      "FLUX",
+
+                      "Factor",
+
+                      "Fancy",
+
+                      "Fantom",
+
+                      "Faust",
+
+                      "Fennel",
+
+                      "Filebench WML",
+
+                      "Filterscript",
+
+                      "Fluent",
+
+                      "Formatted",
+
+                      "Forth",
+
+                      "Fortran Free Form",
+
+                      "Fortran",
+
+                      "FreeBasic",
+
+                      "Frege",
+
+                      "Futhark",
+
+                      "G-code",
+
+                      "GAML",
+
+                      "GAMS",
+
+                      "GAP",
+
+                      "GCC Machine Description",
+
+                      "GDB",
+
+                      "GDScript",
+
+                      "GEDCOM",
+
+                      "GLSL",
+
+                      "GN",
+
+                      "Game Maker Language",
+
+                      "Gemfile.lock",
+
+                      "Genie",
+
+                      "Genshi",
+
+                      "Gentoo Eclass",
+
+                      "Gerber Image",
+
+                      "Gettext Catalog",
+
+                      "Gherkin",
+
+                      "Git Config",
+
+                      "Glyph Bitmap Distribution Format",
+
+                      "Glyph",
+
+                      "Gnuplot",
+
+                      "Go Checksums",
+
+                      "Go Module",
+
+                      "Go",
+
+                      "Golo",
+
+                      "Gosu",
+
+                      "Grace",
+
+                      "Gradle",
+
+                      "Grammatical Framework",
+
+                      "Graph Modeling Language",
+
+                      "GraphQL",
+
+                      "Graphviz (DOT)",
+
+                      "Groovy Server Pages",
+
+                      "Groovy",
+
+                      "HAProxy",
+
+                      "HCL",
+
+                      "HTML",
+
+                      "HTML+ECR",
+
+                      "HTML+EEX",
+
+                      "HTML+ERB",
+
+                      "HTML+PHP",
+
+                      "HTML+Razor",
+
+                      "HTTP",
+
+                      "HXML",
+
+                      "Hack",
+
+                      "Haml",
+
+                      "Handlebars",
+
+                      "Harbour",
+
+                      "HashiCorp Configuration Language",
+
+                      "Haskell",
+
+                      "Haxe",
+
+                      "HiveQL",
+
+                      "HolyC",
+
+                      "Hy",
+
+                      "IDL",
+
+                      "IGOR Pro",
+
+                      "IPython Notebook",
+
+                      "Idris",
+
+                      "Ignore List",
+
+                      "ImageJ Macro",
+
+                      "Inform 7",
+
+                      "Io",
+
+                      "Ioke",
+
+                      "Isabelle ROOT",
+
+                      "Isabelle",
+
+                      "J",
+
+                      "JAR Manifest",
+
+                      "JFlex",
+
+                      "JSON with Comments",
+
+                      "JSON",
+
+                      "JSON5",
+
+                      "JSONLD",
+
+                      "JSONiq",
+
+                      "Jasmin",
+
+                      "Java Properties",
+
+                      "Java Server Pages",
+
+                      "Java",
+
+                      "JavaScript",
+
+                      "JavaScript+ERB",
+
+                      "Jest Snapshot",
+
+                      "Jinja",
+
+                      "Jison Lex",
+
+                      "Jison",
+
+                      "Jolie",
+
+                      "Jsonnet",
+
+                      "Julia",
+
+                      "Jupyter Notebook",
+
+                      "Kaitai Struct",
+
+                      "KakouneScript",
+
+                      "KiCad Layout",
+
+                      "KiCad Legacy Layout",
+
+                      "KiCad Schematic",
+
+                      "Kit",
+
+                      "Kotlin",
+
+                      "Kusto",
+
+                      "LFE",
+
+                      "LLVM",
+
+                      "LOLCODE",
+
+                      "LSL",
+
+                      "LTspice Symbol",
+
+                      "LabVIEW",
+
+                      "Lark",
+
+                      "Lasso",
+
+                      "Lean",
+
+                      "Less",
+
+                      "Lex",
+
+                      "LilyPond",
+
+                      "Limbo",
+
+                      "Linker Script",
+
+                      "Linux Kernel Module",
+
+                      "Liquid",
+
+                      "Literate Agda",
+
+                      "Literate CoffeeScript",
+
+                      "Literate Haskell",
+
+                      "LiveScript",
+
+                      "Logos",
+
+                      "Logtalk",
+
+                      "LookML",
+
+                      "LoomScript",
+
+                      "Lua",
+
+                      "M",
+
+                      "M4",
+
+                      "M4Sugar",
+
+                      "MATLAB",
+
+                      "MAXScript",
+
+                      "MLIR",
+
+                      "MQL4",
+
+                      "MQL5",
+
+                      "MTML",
+
+                      "MUF",
+
+                      "Macaulay2",
+
+                      "Makefile",
+
+                      "Mako",
+
+                      "Markdown",
+
+                      "Marko",
+
+                      "Mathematica",
+
+                      "Max",
+
+                      "Mercury",
+
+                      "Meson",
+
+                      "Metal",
+
+                      "Microsoft Developer Studio Project",
+
+                      "Microsoft Visual Studio Solution",
+
+                      "MiniD",
+
+                      "Mirah",
+
+                      "Modelica",
+
+                      "Modula-2",
+
+                      "Modula-3",
+
+                      "Module Management System",
+
+                      "Monkey",
+
+                      "Moocode",
+
+                      "MoonScript",
+
+                      "Motoko",
+
+                      "Motorola 68K Assembly",
+
+                      "Muse",
+
+                      "Myghty",
+
+                      "NASL",
+
+                      "NCL",
+
+                      "NEON",
+
+                      "NPM Config",
+
+                      "NSIS",
+
+                      "NWScript",
+
+                      "Nearley",
+
+                      "Nemerle",
+
+                      "NeoSnippet",
+
+                      "NetLinx",
+
+                      "NetLinx+ERB",
+
+                      "NetLogo",
+
+                      "NewLisp",
+
+                      "Nextflow",
+
+                      "Nginx",
+
+                      "Ninja",
+
+                      "Nit",
+
+                      "Nix",
+
+                      "NumPy",
+
+                      "Nunjucks",
+
+                      "ObjDump",
+
+                      "Object Data Instance Notation",
+
+                      "ObjectScript",
+
+                      "Objective-C",
+
+                      "Objective-C++",
+
+                      "Objective-J",
+
+                      "Odin",
+
+                      "Omgrofl",
+
+                      "Opa",
+
+                      "Opal",
+
+                      "Open Policy Agent",
+
+                      "OpenCL",
+
+                      "OpenEdge ABL",
+
+                      "OpenQASM",
+
+                      "OpenRC runscript",
+
+                      "OpenSCAD",
+
+                      "OpenStep Property List",
+
+                      "OpenType Feature File",
+
+                      "Org",
+
+                      "Ox",
+
+                      "Oxygene",
+
+                      "Oz",
+
+                      "P4",
+
+                      "PEG.js",
+
+                      "PHP",
+
+                      "PLpgSQL",
+
+                      "POV-Ray SDL",
+
+                      "Pan",
+
+                      "Papyrus",
+
+                      "Parrot Assembly",
+
+                      "Parrot Internal Representation",
+
+                      "Parrot",
+
+                      "Pascal",
+
+                      "Pawn",
+
+                      "Pep8",
+
+                      "Perl",
+
+                      "Pickle",
+
+                      "PicoLisp",
+
+                      "PigLatin",
+
+                      "Pike",
+
+                      "PlantUML",
+
+                      "Pod 6",
+
+                      "Pod",
+
+                      "PogoScript",
+
+                      "Pony",
+
+                      "PostCSS",
+
+                      "PostScript",
+
+                      "PowerShell",
+
+                      "Prisma",
+
+                      "Processing",
+
+                      "Proguard",
+
+                      "Prolog",
+
+                      "Promela",
+
+                      "Propeller Spin",
+
+                      "Protocol Buffer",
+
+                      "Protocol Buffers",
+
+                      "Public Key",
+
+                      "Pug",
+
+                      "Puppet",
+
+                      "Pure Data",
+
+                      "PureBasic",
+
+                      "PureScript",
+
+                      "Python",
+
+                      "Q#",
+
+                      "QMake",
+
+                      "Qt Script",
+
+                      "Quake",
+
+                      "R",
+
+                      "RAML",
+
+                      "RDoc",
+
+                      "REALbasic",
+
+                      "REXX",
+
+                      "RMarkdown",
+
+                      "RPC",
+
+                      "RPM Spec",
+
+                      "Racket",
+
+                      "Ragel",
+
+                      "Raw token data",
+
+                      "ReScript",
+
+                      "Readline Config",
+
+                      "Reason",
+
+                      "Rebol",
+
+                      "Record Jar",
+
+                      "Red",
+
+                      "Redirect Rules",
+
+                      "Regular Expression",
+
+                      "RenderScript",
+
+                      "Rich Text Format",
+
+                      "Ring",
+
+                      "Riot",
+
+                      "RobotFramework",
+
+                      "Roff",
+
+                      "Rouge",
+
+                      "Rscript",
+
+                      "Ruby",
+
+                      "Rust",
+
+                      "SAS",
+
+                      "SCSS",
+
+                      "SELinux Kernel Policy Language",
+
+                      "SELinux Policy",
+
+                      "SMT",
+
+                      "SPARQL",
+
+                      "SQF",
+
+                      "SQL",
+
+                      "SQLPL",
+
+                      "SRecode Template",
+
+                      "SSH Config",
+
+                      "STON",
+
+                      "SVG",
+
+                      "SWIG",
+
+                      "Sage",
+
+                      "SaltStack",
+
+                      "Sass",
+
+                      "Scala",
+
+                      "Scaml",
+
+                      "Scheme",
+
+                      "Scilab",
+
+                      "Self",
+
+                      "ShaderLab",
+
+                      "Shell",
+
+                      "ShellCheck Config",
+
+                      "Sieve",
+
+                      "Singularity",
+
+                      "Slash",
+
+                      "Slice",
+
+                      "Slim",
+
+                      "SmPL",
+
+                      "Smalltalk",
+
+                      "SnipMate",
+
+                      "Solidity",
+
+                      "Soong",
+
+                      "SourcePawn",
+
+                      "Spline Font Database",
+
+                      "Squirrel",
+
+                      "Stan",
+
+                      "Standard ML",
+
+                      "Starlark",
+
+                      "StringTemplate",
+
+                      "Stylus",
+
+                      "SubRip Text",
+
+                      "SugarSS",
+
+                      "SuperCollider",
+
+                      "Svelte",
+
+                      "Swift",
+
+                      "SystemVerilog",
+
+                      "TI Program",
+
+                      "TLA",
+
+                      "TOML",
+
+                      "TSQL",
+
+                      "TSV",
+
+                      "TSX",
+
+                      "TXL",
+
+                      "Tcl",
+
+                      "Tcsh",
+
+                      "TeX",
+
+                      "Tea",
+
+                      "Terra",
+
+                      "Texinfo",
+
+                      "Text",
+
+                      "TextMate Properties",
+
+                      "Textile",
+
+                      "Thrift",
+
+                      "Turing",
+
+                      "Turtle",
+
+                      "Twig",
+
+                      "Type Language",
+
+                      "TypeScript",
+
+                      "UltiSnip",
+
+                      "UltiSnips",
+
+                      "Unified Parallel C",
+
+                      "Unity3D Asset",
+
+                      "Unix Assembly",
+
+                      "Uno",
+
+                      "UnrealScript",
+
+                      "Ur",
+
+                      "Ur/Web",
+
+                      "UrWeb",
+
+                      "V",
+
+                      "VBA",
+
+                      "VCL",
+
+                      "VHDL",
+
+                      "Vala",
+
+                      "Valve Data Format",
+
+                      "Verilog",
+
+                      "Vim Help File",
+
+                      "Vim Script",
+
+                      "Vim Snippet",
+
+                      "Visual Basic .NET",
+
+                      "Vue",
+
+                      "Wavefront Material",
+
+                      "Wavefront Object",
+
+                      "Web Ontology Language",
+
+                      "WebAssembly",
+
+                      "WebVTT",
+
+                      "Wget Config",
+
+                      "Wikitext",
+
+                      "Windows Registry Entries",
+
+                      "Wollok",
+
+                      "World of Warcraft Addon Data",
+
+                      "X BitMap",
+
+                      "X Font Directory Index",
+
+                      "X PixMap",
+
+                      "X10",
+
+                      "XC",
+
+                      "XCompose",
+
+                      "XML Property List",
+
+                      "XML",
+
+                      "XPages",
+
+                      "XProc",
+
+                      "XQuery",
+
+                      "XS",
+
+                      "XSLT",
+
+                      "Xojo",
+
+                      "Xonsh",
+
+                      "Xtend",
+
+                      "YAML",
+
+                      "YANG",
+
+                      "YARA",
+
+                      "YASnippet",
+
+                      "Yacc",
+
+                      "ZAP",
+
+                      "ZIL",
+
+                      "Zeek",
+
+                      "ZenScript",
+
+                      "Zephir",
+
+                      "Zig",
+
+                      "Zimpl",
+
+                      "abl",
+
+                      "abuild",
+
+                      "acfm",
+
+                      "aconf",
+
+                      "actionscript 3",
+
+                      "actionscript3",
+
+                      "ada2005",
+
+                      "ada95",
+
+                      "adobe composite font metrics",
+
+                      "adobe multiple font metrics",
+
+                      "advpl",
+
+                      "ags",
+
+                      "ahk",
+
+                      "altium",
+
+                      "amfm",
+
+                      "amusewiki",
+
+                      "apache",
+
+                      "apkbuild",
+
+                      "arexx",
+
+                      "as3",
+
+                      "asm",
+
+                      "asp",
+
+                      "aspx",
+
+                      "aspx-vb",
+
+                      "ats2",
+
+                      "au3",
+
+                      "autoconf",
+
+                      "b3d",
+
+                      "bash session",
+
+                      "bash",
+
+                      "bat",
+
+                      "batch",
+
+                      "bazel",
+
+                      "blitz3d",
+
+                      "blitzplus",
+
+                      "bmax",
+
+                      "bplus",
+
+                      "bro",
+
+                      "bsdmake",
+
+                      "byond",
+
+                      "bzl",
+
+                      "c++-objdump",
+
+                      "c2hs",
+
+                      "cURL Config",
+
+                      "cake",
+
+                      "cakescript",
+
+                      "cfc",
+
+                      "cfm",
+
+                      "cfml",
+
+                      "chpl",
+
+                      "clipper",
+
+                      "coccinelle",
+
+                      "coffee",
+
+                      "coffee-script",
+
+                      "coldfusion html",
+
+                      "console",
+
+                      "cperl",
+
+                      "cpp",
+
+                      "csharp",
+
+                      "csound-csd",
+
+                      "csound-orc",
+
+                      "csound-sco",
+
+                      "cucumber",
+
+                      "curlrc",
+
+                      "cwl",
+
+                      "dcl",
+
+                      "delphi",
+
+                      "desktop",
+
+                      "dircolors",
+
+                      "django",
+
+                      "dosbatch",
+
+                      "dosini",
+
+                      "dpatch",
+
+                      "dtrace-script",
+
+                      "eC",
+
+                      "ecr",
+
+                      "editor-config",
+
+                      "edn",
+
+                      "eeschema schematic",
+
+                      "eex",
+
+                      "elisp",
+
+                      "emacs muse",
+
+                      "emacs",
+
+                      "email",
+
+                      "eml",
+
+                      "erb",
+
+                      "fb",
+
+                      "fish",
+
+                      "flex",
+
+                      "foxpro",
+
+                      "fsharp",
+
+                      "fstar",
+
+                      "ftl",
+
+                      "fundamental",
+
+                      "gf",
+
+                      "git-ignore",
+
+                      "gitattributes",
+
+                      "gitconfig",
+
+                      "gitignore",
+
+                      "gitmodules",
+
+                      "go mod",
+
+                      "go sum",
+
+                      "go.mod",
+
+                      "go.sum",
+
+                      "golang",
+
+                      "groff",
+
+                      "gsp",
+
+                      "hbs",
+
+                      "heex",
+
+                      "help",
+
+                      "html+django",
+
+                      "html+jinja",
+
+                      "html+ruby",
+
+                      "htmlbars",
+
+                      "htmldjango",
+
+                      "hylang",
+
+                      "i7",
+
+                      "ignore",
+
+                      "igor",
+
+                      "igorpro",
+
+                      "ijm",
+
+                      "inc",
+
+                      "inform7",
+
+                      "inputrc",
+
+                      "irc logs",
+
+                      "irc",
+
+                      "java server page",
+
+                      "jq",
+
+                      "jruby",
+
+                      "js",
+
+                      "jsonc",
+
+                      "jsp",
+
+                      "kak",
+
+                      "kakscript",
+
+                      "keyvalues",
+
+                      "ksy",
+
+                      "lassoscript",
+
+                      "latex",
+
+                      "leex",
+
+                      "lhaskell",
+
+                      "lhs",
+
+                      "lisp",
+
+                      "litcoffee",
+
+                      "live-script",
+
+                      "ls",
+
+                      "m2",
+
+                      "m68k",
+
+                      "mIRC Script",
+
+                      "macruby",
+
+                      "mail",
+
+                      "make",
+
+                      "man page",
+
+                      "man",
+
+                      "man-page",
+
+                      "manpage",
+
+                      "markojs",
+
+                      "max/msp",
+
+                      "maxmsp",
+
+                      "mbox",
+
+                      "mcfunction",
+
+                      "mdoc",
+
+                      "mediawiki",
+
+                      "mf",
+
+                      "mma",
+
+                      "mumps",
+
+                      "mupad",
+
+                      "nanorc",
+
+                      "nasm",
+
+                      "ne-on",
+
+                      "nesC",
+
+                      "nette object notation",
+
+                      "nginx configuration file",
+
+                      "nixos",
+
+                      "njk",
+
+                      "node",
+
+                      "npmrc",
+
+                      "nroff",
+
+                      "nush",
+
+                      "nvim",
+
+                      "obj-c",
+
+                      "obj-c++",
+
+                      "obj-j",
+
+                      "objc",
+
+                      "objc++",
+
+                      "objectivec",
+
+                      "objectivec++",
+
+                      "objectivej",
+
+                      "objectpascal",
+
+                      "objj",
+
+                      "octave",
+
+                      "odin-lang",
+
+                      "odinlang",
+
+                      "oncrpc",
+
+                      "ooc",
+
+                      "openedge",
+
+                      "openrc",
+
+                      "osascript",
+
+                      "pandoc",
+
+                      "pasm",
+
+                      "pcbnew",
+
+                      "perl-6",
+
+                      "perl6",
+
+                      "pir",
+
+                      "plain text",
+
+                      "posh",
+
+                      "postscr",
+
+                      "pot",
+
+                      "pov-ray",
+
+                      "povray",
+
+                      "progress",
+
+                      "protobuf",
+
+                      "pwsh",
+
+                      "pycon",
+
+                      "pyrex",
+
+                      "python3",
+
+                      "q",
+
+                      "ql",
+
+                      "qsharp",
+
+                      "ragel-rb",
+
+                      "ragel-ruby",
+
+                      "rake",
+
+                      "raw",
+
+                      "razor",
+
+                      "rb",
+
+                      "rbx",
+
+                      "reStructuredText",
+
+                      "readline",
+
+                      "red/system",
+
+                      "redirects",
+
+                      "regex",
+
+                      "regexp",
+
+                      "renpy",
+
+                      "rhtml",
+
+                      "robots txt",
+
+                      "robots",
+
+                      "robots.txt",
+
+                      "rpcgen",
+
+                      "rs",
+
+                      "rs-274x",
+
+                      "rss",
+
+                      "rst",
+
+                      "rusthon",
+
+                      "salt",
+
+                      "saltstate",
+
+                      "sed",
+
+                      "sepolicy",
+
+                      "sh",
+
+                      "shell-script",
+
+                      "shellcheckrc",
+
+                      "sml",
+
+                      "snippet",
+
+                      "sourcemod",
+
+                      "soy",
+
+                      "specfile",
+
+                      "splus",
+
+                      "squeak",
+
+                      "terraform",
+
+                      "tl",
+
+                      "tm-properties",
+
+                      "troff",
+
+                      "ts",
+
+                      "udiff",
+
+                      "vb .net",
+
+                      "vb.net",
+
+                      "vb6",
+
+                      "vbnet",
+
+                      "vdf",
+
+                      "vim",
+
+                      "vimhelp",
+
+                      "viml",
+
+                      "visual basic 6",
+
+                      "visual basic for applications",
+
+                      "visual basic",
+
+                      "vlang",
+
+                      "wasm",
+
+                      "wast",
+
+                      "wdl",
+
+                      "wgetrc",
+
+                      "wiki",
+
+                      "winbatch",
+
+                      "wisp",
+
+                      "wl",
+
+                      "wolfram lang",
+
+                      "wolfram language",
+
+                      "wolfram",
+
+                      "wsdl",
+
+                      "xBase",
+
+                      "xbm",
+
+                      "xdr",
+
+                      "xhtml",
+
+                      "xml+genshi",
+
+                      "xml+kid",
+
+                      "xpm",
+
+                      "xsd",
+
+                      "xsl",
+
+                      "xten",
+
+                      "yas",
+
+                      "yml",
+
+                      "zsh"
+                    ]
+                  }
+                },
+
+                "additionalProperties": false
+              },
+
+              "validations": {
+                "$ref": "#/definitions/validations",
+
+                "title": "textarea validations",
+
+                "description": "Textarea validations\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#validations"
+              }
+            },
+
+            "additionalProperties": false
+          }
+        },
+
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "input"
+              }
+            }
+          },
+
+          "then": {
+            "$comment": "For `additionalProperties` to work `type` must also be present here.",
+
+            "title": "input",
+
+            "description": "Input\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#input",
+
+            "type": "object",
+
+            "required": ["type", "attributes"],
+
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/type"
+              },
+
+              "id": {
+                "$ref": "#/definitions/id",
+
+                "description": "An input id\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#keys"
+              },
+
+              "attributes": {
+                "title": "input attributes",
+
+                "description": "Input attributes\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-2",
+
+                "type": "object",
+
+                "required": ["label"],
+
+                "properties": {
+                  "label": {
+                    "$ref": "#/definitions/label",
+
+                    "description": "A short input description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-2"
+                  },
+
+                  "description": {
+                    "$ref": "#/definitions/description",
+
+                    "description": "A long input description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-2"
+                  },
+
+                  "placeholder": {
+                    "$ref": "#/definitions/placeholder",
+
+                    "description": "An input placeholder\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-2"
+                  },
+
+                  "value": {
+                    "$ref": "#/definitions/value",
+
+                    "description": "An input value\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-2"
+                  }
+                },
+
+                "additionalProperties": false
+              },
+
+              "validations": {
+                "$ref": "#/definitions/validations",
+
+                "title": "input validations",
+
+                "description": "Input validations\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#validations-1"
+              }
+            },
+
+            "additionalProperties": false
+          }
+        },
+
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "dropdown"
+              }
+            }
+          },
+
+          "then": {
+            "$comment": "For `additionalProperties` to work `type` must also be present here.",
+
+            "title": "dropdown",
+
+            "description": "dropdown\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#dropdown",
+
+            "type": "object",
+
+            "required": ["type", "attributes"],
+
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/type"
+              },
+
+              "id": {
+                "$ref": "#/definitions/id",
+
+                "description": "A dropdown id\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#keys"
+              },
+
+              "attributes": {
+                "title": "dropdown attributes",
+
+                "description": "Dropdown attributes\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-3",
+
+                "type": "object",
+
+                "required": ["label", "options"],
+
+                "properties": {
+                  "label": {
+                    "$ref": "#/definitions/label",
+
+                    "description": "A short dropdown description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-3"
+                  },
+
+                  "description": {
+                    "$ref": "#/definitions/description",
+
+                    "description": "A long dropdown description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-3"
+                  },
+
+                  "multiple": {
+                    "description": "Specify whether allow a multiple choices\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-3",
+
+                    "type": "boolean",
+
+                    "default": false
+                  },
+
+                  "options": {
+                    "description": "Dropdown choices\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-3",
+
+                    "type": "array",
+
+                    "minItems": 1,
+
+                    "uniqueItems": true,
+
+                    "items": {
+                      "type": "string",
+
+                      "minLength": 1,
+
+                      "examples": ["Sample choice"]
+                    }
+                  },
+
+                  "default": {
+                    "description": "Index of the default option\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-3",
+
+                    "type": "integer",
+
+                    "examples": [0]
+                  }
+                },
+
+                "additionalProperties": false
+              },
+
+              "validations": {
+                "$ref": "#/definitions/validations",
+
+                "title": "dropdown validations",
+
+                "description": "Dropdown validations\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#validations-2"
+              }
+            },
+
+            "additionalProperties": false
+          }
+        },
+
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "checkboxes"
+              }
+            }
+          },
+
+          "then": {
+            "$comment": "For `additionalProperties` to work `type` must also be present here.",
+
+            "title": "checkboxes",
+
+            "description": "Checkboxes\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#checkboxes",
+
+            "type": "object",
+
+            "required": ["type", "attributes"],
+
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/type"
+              },
+
+              "id": {
+                "$ref": "#/definitions/id",
+
+                "description": "Checkbox list id\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#keys"
+              },
+
+              "attributes": {
+                "title": "checkbox list attributes",
+
+                "description": "Checkbox list attributes\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-4",
+
+                "type": "object",
+
+                "required": ["label", "options"],
+
+                "properties": {
+                  "label": {
+                    "$ref": "#/definitions/label",
+
+                    "description": "A short checkbox list description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-4"
+                  },
+
+                  "description": {
+                    "$ref": "#/definitions/description",
+
+                    "description": "A long checkbox list description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-4"
+                  },
+
+                  "options": {
+                    "description": "Checkbox list choices\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-4",
+
+                    "type": "array",
+
+                    "minItems": 1,
+
+                    "items": {
+                      "title": "checkbox list choice",
+
+                      "description": "Checkbox list choice\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-4",
+
+                      "type": "object",
+
+                      "required": ["label"],
+
+                      "properties": {
+                        "label": {
+                          "description": "A short checkbox list choice description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-4",
+
+                          "type": "string",
+
+                          "minLength": 1,
+
+                          "examples": ["Sample label"]
+                        },
+
+                        "required": {
+                          "description": "Specify whether a choice is required\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#attributes-4",
+
+                          "type": "boolean",
+
+                          "default": false
+                        }
+                      },
+
+                      "additionalProperties": false
+                    }
+                  }
+                },
+
+                "additionalProperties": false
+              }
+            },
+
+            "additionalProperties": false
+          }
+        }
+      ]
+    }
+  },
+
+  "properties": {
+    "name": {
+      "description": "An issue template name\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax",
+
+      "type": "string",
+
+      "minLength": 1,
+
+      "examples": ["Sample name"]
+    },
+
+    "description": {
+      "description": "An issue template description\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax",
+
+      "type": "string",
+
+      "minLength": 1,
+
+      "examples": ["Sample description"]
+    },
+
+    "body": {
+      "description": "An issue template body\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax",
+
+      "type": "array",
+
+      "minItems": 1,
+
+      "items": {
+        "$ref": "#/definitions/form_item"
+      }
+    },
+
+    "assignees": {
+      "description": "An issue template assignees\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax",
+
+      "oneOf": [
+        {
+          "$ref": "#/definitions/assignee"
+        },
+
+        {
+          "type": "array",
+
+          "minItems": 1,
+
+          "uniqueItems": true,
+
+          "items": {
+            "$ref": "#/definitions/assignee"
+          }
+        }
+      ]
+    },
+
+    "labels": {
+      "description": "An issue template labels\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax",
+
+      "type": "array",
+
+      "minItems": 1,
+
+      "uniqueItems": true,
+
+      "items": {
+        "type": "string",
+
+        "minLength": 1,
+
+        "examples": [
+          "Sample label",
+
+          "bug",
+
+          "documentation",
+
+          "duplicate",
+
+          "enhancement",
+
+          "good first issue",
+
+          "help wanted",
+
+          "invalid",
+
+          "question",
+
+          "wontfix"
+        ]
+      }
+    },
+
+    "title": {
+      "description": "An issue template title\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax",
+
+      "type": "string",
+
+      "minLength": 1,
+
+      "examples": ["Sample title", "Bug: ", "Feature: "]
+    }
+  },
+
+  "required": ["name", "description", "body"],
+
+  "title": "GitHub issue forms config file schema",
+
+  "type": "object"
+}


### PR DESCRIPTION
This validates the GitHub issue tempaltes against a schema, and would have caught the issue that was fixed by https://github.com/UCL-ARC/python-tooling/pull/306. 

Unfortunately it's not possible to validate the package template files as they contain invalid characters for a string entry (`{` and `}`).