### PR TITLE
Correct uses of project_name in pyproject.toml

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -49,7 +49,7 @@ urls.homepage = "https://github.com/{{cookiecutter.github_username}}/{{cookiecut
 [tool.coverage]
 report = {skip_covered = true, sort = "cover"}
 run = {branch = true, parallel = true, source = [
-    "{{cookiecutter.project_slug}}",
+    "{{cookiecutter.project_name}}",
 ]}
 paths.source = [
     "src",
@@ -88,7 +88,7 @@ lint.select = [
     "ALL",
 ]
 lint.isort.known-first-party = [
-    "{{cookiecutter.project_slug | replace('-', '_')}}",
+    "{{cookiecutter.project_name}}",
 ]
 lint.mccabe.max-complexity = 18
 lint.pep8-naming.classmethod-decorators = [


### PR DESCRIPTION
1. Fix `[tool.coverage]` so coverage data is collected correctly. I haven't come up with a way to test this, other than this is the fix I needed at https://github.com/hipCTProject/hipct-reg
2. While I was at it, I noticed a second place where custom logic could just be repalced with project_name