### PR TITLE
Don't try and measure coverage of .tox installation

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -53,7 +53,6 @@ run = {branch = true, parallel = true, source = [
 ]}
 paths.source = [
     "src",
-    ".tox*/*/lib/python*/site-packages",
 ]
 
 [tool.mypy]


### PR DESCRIPTION
I'm not too sure why this line is here, but I don't *think* it's needed since either:
- You're running `pytest` and the source code is in ./src
- You're running `tox` and tox installs the package in it's own virtual environment, and the source code is still at ./src relative to the installed pyproject.toml file