### PR TITLE
Dark mode.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,6 +4,8 @@ theme: just-the-docs
 
 url: https://UCL-ARC.github.io/python-tooling
 
+color_scheme: dark
+
 aux_links:
   Source repository: https://github.com/UCL-ARC/python-tooling
 

--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -1,0 +1,15 @@
+<button class="btn js-toggle-dark-mode">View pages in light mode</button>
+
+<script>
+const toggleDarkMode = document.querySelector('.js-toggle-dark-mode');
+
+jtd.addEvent(toggleDarkMode, 'click', function(){
+  if (jtd.getTheme() === 'light') {
+    jtd.setTheme('dark');
+    toggleDarkMode.textContent = '☼';
+  } else {
+    jtd.setTheme('light');
+    toggleDarkMode.textContent = '☾';
+  }
+});
+</script>

--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -1,15 +1,15 @@
 <button class="btn js-toggle-dark-mode">View pages in light mode</button>
 
 <script>
-const toggleDarkMode = document.querySelector('.js-toggle-dark-mode');
+  const toggleDarkMode = document.querySelector(".js-toggle-dark-mode");
 
-jtd.addEvent(toggleDarkMode, 'click', function(){
-  if (jtd.getTheme() === 'light') {
-    jtd.setTheme('dark');
-    toggleDarkMode.textContent = '☼';
-  } else {
-    jtd.setTheme('light');
-    toggleDarkMode.textContent = '☾';
-  }
-});
+  jtd.addEvent(toggleDarkMode, "click", function () {
+    if (jtd.getTheme() === "light") {
+      jtd.setTheme("dark");
+      toggleDarkMode.textContent = "☼";
+    } else {
+      jtd.setTheme("light");
+      toggleDarkMode.textContent = "☾";
+    }
+  });
 </script>

--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -1,4 +1,4 @@
-<button class="btn js-toggle-dark-mode">View pages in light mode</button>
+<button class="btn js-toggle-dark-mode">☼</button>
 
 <script>
   const toggleDarkMode = document.querySelector(".js-toggle-dark-mode");


### PR DESCRIPTION
Changes the docs pages to dark mode by default and adds a switcher button to the top bar.

The first time around there is an explicit "View these pages in light mode" then subsequently, it's the sun and moon characters.

https://github.com/UCL-ARC/python-tooling/assets/1836192/b003bfd8-fa35-444f-8e41-0ee77173363d

## Up for debate

My proposal is this. But I made two decisions (which you might disagree with).

* Dark mode by default.
* Words first, then ☼/☾ characters.

JTD doesn't seem to support just taking the system theme (yet).
- https://github.com/just-the-docs/just-the-docs/issues/1223