### PR TITLE
Remove mentions of mamba

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Python packages with our recommended tooling set up and ready to go.
 
 ## Using this template
 
-1.  Install [cookiecutter] in a `conda` or `venv` environment
-    (commented lines for conda example).
+1.  Install [cookiecutter] in a Conda or `venv` environment
+    (commented lines for Conda example).
 
     ```
     # conda create --channel conda-forge --name new-env-name

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Python packages with our recommended tooling set up and ready to go.
 
 ## Using this template
 
-1.  Install [cookiecutter] in a `conda`, `mamba` or `venv` environment
+1.  Install [cookiecutter] in a `conda` or `venv` environment
     (commented lines for conda example).
 
     ```

--- a/docs/pages/dev.md
+++ b/docs/pages/dev.md
@@ -5,14 +5,13 @@ layout: default
 
 # Virtual environments
 
-| Name                                                                  | Short description                                                                   | 🚦  |
-| --------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | :-: |
-| [mamba](https://mamba.readthedocs.io/en/latest/user_guide/mamba.html) | A tool to manage conda environments. Faster than conda for installing dependencies. | 🟢  |
-| [conda](https://conda.io/projects/conda/en/latest/)                   | Conda quickly installs, runs, and updates packages and their dependencies.          | 🟠  |
-| [pipenv](https://pipenv.pypa.io/en/latest/)                           | A tool that automatically creates and manages a virtualenv for your projects.       | 🟠  |
-| [pyenv](https://github.com/pyenv/pyenv)                               | A tool that lets you easily switch between multiple versions of Python.             | 🟠  |
-| [virtualenv](https://virtualenv.pypa.io/en/latest/)                   | A tool to create isolated Python environments which offers more features than venv. | 🟠  |
-| [venv](https://docs.python.org/3/library/venv.html)                   | A tool to create isolated Python environments.                                      | 🔴  |
+| Name                                                | Short description                                                                   | 🚦  |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------- | :-: |
+| [conda](https://conda.io/projects/conda/en/latest/) | Conda quickly installs, runs, and updates packages and their dependencies.          | 🟢  |
+| [pipenv](https://pipenv.pypa.io/en/latest/)         | A tool that automatically creates and manages a virtualenv for your projects.       | 🟠  |
+| [pyenv](https://github.com/pyenv/pyenv)             | A tool that lets you easily switch between multiple versions of Python.             | 🟠  |
+| [virtualenv](https://virtualenv.pypa.io/en/latest/) | A tool to create isolated Python environments which offers more features than venv. | 🟠  |
+| [venv](https://docs.python.org/3/library/venv.html) | A tool to create isolated Python environments.                                      | 🔴  |
 
 # Other
 

--- a/docs/pages/dev.md
+++ b/docs/pages/dev.md
@@ -5,13 +5,13 @@ layout: default
 
 # Virtual environments
 
-| Name                                                | Short description                                                                   | 🚦  |
-| --------------------------------------------------- | ----------------------------------------------------------------------------------- | :-: |
-| [conda](https://conda.io/projects/conda/en/latest/) | Conda quickly installs, runs, and updates packages and their dependencies.          | 🟢  |
-| [pipenv](https://pipenv.pypa.io/en/latest/)         | A tool that automatically creates and manages a virtualenv for your projects.       | 🟠  |
-| [pyenv](https://github.com/pyenv/pyenv)             | A tool that lets you easily switch between multiple versions of Python.             | 🟠  |
-| [virtualenv](https://virtualenv.pypa.io/en/latest/) | A tool to create isolated Python environments which offers more features than venv. | 🟠  |
-| [venv](https://docs.python.org/3/library/venv.html) | A tool to create isolated Python environments.                                      | 🔴  |
+| Name                                                    | Short description                                                                   | 🚦  |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------- | :-: |
+| [Conda](https://docs.conda.io/projects/conda/en/stable/ | Conda quickly installs, runs, and updates packages and their dependencies.          | 🟢  |
+| [pipenv](https://pipenv.pypa.io/en/latest/)             | A tool that automatically creates and manages a virtualenv for your projects.       | 🟠  |
+| [pyenv](https://github.com/pyenv/pyenv)                 | A tool that lets you easily switch between multiple versions of Python.             | 🟠  |
+| [virtualenv](https://virtualenv.pypa.io/en/latest/)     | A tool to create isolated Python environments which offers more features than venv. | 🟠  |
+| [venv](https://docs.python.org/3/library/venv.html)     | A tool to create isolated Python environments.                                      | 🔴  |
 
 # Other
 

--- a/docs/pages/packaging.md
+++ b/docs/pages/packaging.md
@@ -14,7 +14,7 @@ layout: default
 
 ## Conda
 
-These tools are helpful if you're looking to publish your package on [conda-forge](https://conda-forge.org/), so users can install it through the [conda](https://docs.conda.io/en/latest/) or [mamba](https://mamba.readthedocs.io/en/latest/index.html) package managers.
+These tools are helpful if you're looking to publish your package on [conda-forge](https://conda-forge.org/), so users can install it through the [conda](https://docs.conda.io/en/latest/) package manager.
 
 | Name                                                      | Short description                                                           | 🚦  |
 | --------------------------------------------------------- | --------------------------------------------------------------------------- | :-: |

--- a/docs/pages/packaging.md
+++ b/docs/pages/packaging.md
@@ -14,8 +14,8 @@ layout: default
 
 ## Conda
 
-These tools are helpful if you're looking to publish your package on [conda-forge](https://conda-forge.org/), so users can install it through the [conda](https://docs.conda.io/en/latest/) package manager.
+These tools are helpful if you're looking to publish your package on [conda-forge](https://conda-forge.org/), so users can install it through the [Conda](https://docs.conda.io/projects/conda/en/stable/) package manager.
 
 | Name                                                      | Short description                                                           | 🚦  |
 | --------------------------------------------------------- | --------------------------------------------------------------------------- | :-: |
-| [GraySkull](https://github.com/conda-incubator/grayskull) | A tool for automatic conda recipe generation (aimed at conda-forge, above). | 🟢  |
+| [GraySkull](https://github.com/conda-incubator/grayskull) | A tool for automatic Conda recipe generation (aimed at conda-forge, above). | 🟢  |

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -67,7 +67,7 @@ Centre for Advanced Research Computing, University College London
 
 <!-- How to build or install the application. -->
 
-We recommend installing in a project specific virtual environment created using a environment management tool such as [Mamba](https://mamba.readthedocs.io/en/latest/user_guide/mamba.html) or [Conda](https://conda.io/projects/conda/en/latest/). To install the latest development version of `{{cookiecutter.project_slug}}` using `pip` in the currently active environment run
+We recommend installing in a project specific virtual environment created using a environment management tool such as [Conda](https://docs.conda.io/projects/conda/en/stable/). To install the latest development version of `{{cookiecutter.project_slug}}` using `pip` in the currently active environment run
 
 ```sh
 pip install git+https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}.git


### PR DESCRIPTION
Since the default solver in conda is now libmamba, remove mentions of mamba to simplify recommendations.

I also cleaned the conda links so they point to stable docs (not latest), and did "conda" > "Conda" where appropriate.

Fixes https://github.com/UCL-ARC/python-tooling/issues/301