### PR TITLE
Adding Sphinx docs to template

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ lint.ignore = [
     "D417", # argument description in docstring (unreliable)
     "ISC001", # simplify implicit str concatenation (ruff-format recommended)
 ]
-lint.per-file-ignores = {"*tests*" = [
+lint.per-file-ignores = {"*docs/conf.py" = [
+    "INP001",
+], "*tests*" = [
     "INP001",
     "S101",
 ], "hooks*" = [

--- a/tests/test_package_gen.py
+++ b/tests/test_package_gen.py
@@ -56,6 +56,9 @@ def test_package_generation(
         "tests",
         pathlib.Path(".github"),
         pathlib.Path(".github") / "workflows",
+        pathlib.Path("docs") / "conf.py",
+        pathlib.Path("docs") / "index.md",
+        pathlib.Path("docs") / "_static" / ".gitignore",
     ]
     for f in expected_files:
         full_path = test_project_dir / f

--- a/tests/test_package_gen.py
+++ b/tests/test_package_gen.py
@@ -58,7 +58,6 @@ def test_package_generation(
         pathlib.Path(".github") / "workflows",
         pathlib.Path("docs") / "conf.py",
         pathlib.Path("docs") / "index.md",
-        pathlib.Path("docs") / "_static" / ".gitignore",
     ]
     for f in expected_files:
         full_path = test_project_dir / f

--- a/{{cookiecutter.project_slug}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .tox
-          key: tox-${{ '{{' }} hashFiles('pyproject.toml')${{ '}}' }}
+          key: tox-${{ '{{' }} hashFiles('pyproject.toml') {{ '}}' }}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -29,13 +29,13 @@ jobs:
         run: tox -e docs
     # Uncomment lines below to set-up automatic deployment of documentation to a
     # GitHub Pages website on pushing to main - you will need configure the repository
-    # to deploy from a branch `gh-pages` (https://tinyurl.com/gh-pages-from-branch),
+    # to deploy from a branch gh-pages (https://tinyurl.com/gh-pages-from-branch),
     # which will be created the first time this workflow step is run
     #   - name: Publish documentation on GitHub pages
     #     if: success() && github.event_name != 'pull_request'
     #     uses: peaceiris/actions-gh-pages@v3
     #     with:
-    #       github_token: ${{ '{{' }}  secrets.GITHUB_TOKEN ${{ '}}' }}
+    #       github_token: ${{ '{{' }}  secrets.GITHUB_TOKEN {{ '}}' }}
     #       publish_dir: docs/_build/html
     #       publish_branch: gh-pages
     #       user_name: "github-actions[bot]"

--- a/{{cookiecutter.project_slug}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .tox
-          key: tox-${{hashFiles('pyproject.toml')}}
+          key: tox-${{ '{{' }} hashFiles('pyproject.toml')${{ '}}' }}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -35,7 +35,7 @@ jobs:
     #     if: success() && github.event_name != 'pull_request'
     #     uses: peaceiris/actions-gh-pages@v3
     #     with:
-    #       github_token: ${{ secrets.GITHUB_TOKEN }}
+    #       github_token: ${{ '{{' }}  secrets.GITHUB_TOKEN ${{ '}}' }}
     #       publish_dir: docs/_build/html
     #       publish_branch: gh-pages
     #       user_name: "github-actions[bot]"

--- a/{{cookiecutter.project_slug}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/docs.yml
@@ -1,0 +1,42 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Cache tox
+        uses: actions/cache@v4
+        with:
+          path: .tox
+          key: tox-${{hashFiles('pyproject.toml')}}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+          cache: "pip"
+          cache-dependency-path: "pyproject.toml"
+      - name: Install tox
+        run: python -m pip install tox
+      - name: Build HTML documentation with tox
+        run: tox -e docs
+    # Uncomment lines below to set-up automatic deployment of documentation to a
+    # GitHub Pages website on pushing to main - you will need configure the repository
+    # to deploy from a branch `gh-pages` (https://tinyurl.com/gh-pages-from-branch),
+    # which will be created the first time this workflow step is run
+    #   - name: Publish documentation on GitHub pages
+    #     if: success() && github.event_name != 'pull_request'
+    #     uses: peaceiris/actions-gh-pages@v3
+    #     with:
+    #       github_token: ${{ secrets.GITHUB_TOKEN }}
+    #       publish_dir: docs/_build/html
+    #       publish_branch: gh-pages
+    #       user_name: "github-actions[bot]"
+    #       user_email: "github-actions[bot]@users.noreply.github.com"

--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -71,6 +71,9 @@ instance/
 # Sphinx documentation
 docs/_build/
 
+# sphinx-autodoc2 generated API documentation
+docs/apidocs/
+
 # PyBuilder
 .pybuilder/
 target/

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -17,8 +17,8 @@
 [tests-link]:               https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}/actions/workflows/tests.yml
 [linting-badge]:            https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}/actions/workflows/linting.yml/badge.svg
 [linting-link]:             https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}/actions/workflows/linting.yml
-[documentation-badge]:            https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}/actions/workflows/docs.yml/badge.svg
-[documentation-link]:             https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}/actions/workflows/docs.yml
+[documentation-badge]:      https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}/actions/workflows/docs.yml/badge.svg
+[documentation-link]:       https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}/actions/workflows/docs.yml
 [conda-badge]:              https://img.shields.io/conda/vn/conda-forge/{{cookiecutter.project_slug}}
 [conda-link]:               https://github.com/conda-forge/{{cookiecutter.project_slug}}-feedstock
 [pypi-link]:                https://pypi.org/project/{{cookiecutter.project_slug}}/

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -3,6 +3,7 @@
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Tests status][tests-badge]][tests-link]
 [![Linting status][linting-badge]][linting-link]
+[![Documentation status][documentation-badge]][linting-link]
 [![License][license-badge]](./LICENSE.md)
 
 <!--
@@ -16,6 +17,8 @@
 [tests-link]:               https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}/actions/workflows/tests.yml
 [linting-badge]:            https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}/actions/workflows/linting.yml/badge.svg
 [linting-link]:             https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}/actions/workflows/linting.yml
+[documentation-badge]:            https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}/actions/workflows/docs.yml/badge.svg
+[documentation-link]:             https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}/actions/workflows/docs.yml
 [conda-badge]:              https://img.shields.io/conda/vn/conda-forge/{{cookiecutter.project_slug}}
 [conda-link]:               https://github.com/conda-forge/{{cookiecutter.project_slug}}-feedstock
 [pypi-link]:                https://pypi.org/project/{{cookiecutter.project_slug}}/
@@ -107,6 +110,17 @@ pytest tests
 ```
 
 again from the root of the repository.
+
+### Building documenttion
+
+The Sphinx HTML documentation can be built locally by running
+
+```sh
+tox -e docs
+```
+
+from the root of the repository.
+The built documentation will be written to `docs/_build/html`.
 
 ## Roadmap
 

--- a/{{cookiecutter.project_slug}}/docs/_static/.gitignore
+++ b/{{cookiecutter.project_slug}}/docs/_static/.gitignore
@@ -1,0 +1,7 @@
+# Workaround to allow tracking empty directory to avoid warning when
+# running sphinx-build (source: https://stackoverflow.com/a/932982)
+
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/{{cookiecutter.project_slug}}/docs/_static/.gitignore
+++ b/{{cookiecutter.project_slug}}/docs/_static/.gitignore
@@ -1,7 +1,0 @@
-# Workaround to allow tracking empty directory to avoid warning when
-# running sphinx-build (source: https://stackoverflow.com/a/932982)
-
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/{{cookiecutter.project_slug}}/docs/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/conf.py
@@ -1,0 +1,42 @@
+"""Configuration file for the Sphinx documentation builder."""
+
+import datetime
+from importlib.metadata import version as get_version
+
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "{{cookiecutter.package_name}}"
+author = "{{cookiecutter.author_given_names}} {{cookiecutter.author_family_names}}"
+copyright = f"{datetime.datetime.now(tz=datetime.timezone.utc).year}, {author}"  # noqa: A001
+release = get_version("{{cookiecutter.package_name}}")
+version = ".".join(release.split(".")[:2])
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "autodoc2",
+    "myst_parser",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
+]
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3/", None),
+}
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+autodoc2_packages = ["../src/{{cookiecutter.package_name}}"]
+autodoc2_render_plugin = "myst"
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "pydata_sphinx_theme"
+html_static_path = ["_static"]

--- a/{{cookiecutter.project_slug}}/docs/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/conf.py
@@ -29,8 +29,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
 }
 
-templates_path = ["_templates"]
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build"]
 
 autodoc2_packages = ["../src/{{cookiecutter.package_name}}"]
 autodoc2_render_plugin = "myst"

--- a/{{cookiecutter.project_slug}}/docs/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/conf.py
@@ -46,7 +46,7 @@ html_theme_options = {
         {
             "name": "GitHub",
             "url": "https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}/",
-            "icon": "fa-brands fa-square-github",
+            "icon": "fa-brands fa-github",
             "type": "fontawesome",
         },
     ],

--- a/{{cookiecutter.project_slug}}/docs/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/conf.py
@@ -35,6 +35,8 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 autodoc2_packages = ["../src/{{cookiecutter.package_name}}"]
 autodoc2_render_plugin = "myst"
 
+myst_enable_extensions = ["fieldlist"]
+
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 

--- a/{{cookiecutter.project_slug}}/docs/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/conf.py
@@ -42,3 +42,15 @@ myst_enable_extensions = ["fieldlist"]
 
 html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
+
+
+html_theme_options = {
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}/",
+            "icon": "fa-brands fa-square-github",
+            "type": "fontawesome",
+        },
+    ],
+}

--- a/{{cookiecutter.project_slug}}/docs/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/conf.py
@@ -41,8 +41,6 @@ myst_enable_extensions = ["fieldlist"]
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "pydata_sphinx_theme"
-html_static_path = ["_static"]
-
 
 html_theme_options = {
     "icon_links": [

--- a/{{cookiecutter.project_slug}}/docs/index.md
+++ b/{{cookiecutter.project_slug}}/docs/index.md
@@ -1,0 +1,10 @@
+# {{cookiecutter.project_name}}
+
+{{cookiecutter.project_short_description}}
+
+```{toctree}
+---
+maxdepth: 2
+---
+apidocs/index
+```

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -35,10 +35,10 @@ optional-dependencies = {dev = [
     "mypy",
     "myst-parser",
     "pre-commit",
+    "pydata-sphinx-theme",
     "ruff",
     "sphinx",
     "sphinx-autodoc2",
-    "pydata-sphinx-theme",
     "tox",
     "twine",
 ], test = [
@@ -143,7 +143,7 @@ legacy_tox_ini = """
         sphinx-build -W -b html docs docs/_build/html
     deps =
         myst-parser
+        pydata-sphinx-theme
         sphinx
         sphinx-autodoc2
-        pydata-sphinx-theme
 """

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -33,8 +33,12 @@ name = "{{cookiecutter.project_slug}}"
 optional-dependencies = {dev = [
     "build",
     "mypy",
+    "myst-parser",
     "pre-commit",
     "ruff",
+    "sphinx",
+    "sphinx-autodoc2",
+    "pydata-sphinx-theme",
     "tox",
     "twine",
 ], test = [
@@ -83,6 +87,8 @@ lint.ignore = [
 lint.per-file-ignores = {"tests*" = [
     "INP001",
     "S101",
+], "docs/conf.py" = [
+    "INP001",
 ]}
 lint.select = [
     "ALL",
@@ -131,4 +137,13 @@ legacy_tox_ini = """
     ) %}
         py3{{python_version}}
     {%- endfor %}
+
+    [testenv:docs]
+    commands =
+        sphinx-build -W -b html docs docs/_build/html
+    deps =
+        myst-parser
+        sphinx
+        sphinx-autodoc2
+        pydata-sphinx-theme
 """

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -84,11 +84,11 @@ lint.ignore = [
     "D417", # argument description in docstring (unreliable)
     "ISC001", # simplify implicit str concatenation (ruff-format recommended)
 ]
-lint.per-file-ignores = {"tests*" = [
+lint.per-file-ignores = {"docs/conf.py" = [
+    "INP001",
+], "tests*" = [
     "INP001",
     "S101",
-], "docs/conf.py" = [
-    "INP001",
 ]}
 lint.select = [
     "ALL",

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.package_name}}/__init__.py
@@ -3,7 +3,7 @@ from ._version import __version__  # noqa: F401
 
 
 def example_function(argument: str, keyword_argument: str = "default") -> str:
-    """An example function docstring.
+    """Concatenate string arguments - an example function docstring.
 
     :param argument: An argument.
     :param keyword_argument: A keyword argument with a default value.

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.package_name}}/__init__.py
@@ -2,7 +2,7 @@
 from ._version import __version__  # noqa: F401
 
 
-def example_function(argument: str, keyword_argument: str = "default") -> None:
+def example_function(argument: str, keyword_argument: str = "default") -> str:
     """An example function docstring.
 
     :param argument: An argument.

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.package_name}}/__init__.py
@@ -3,7 +3,8 @@ from ._version import __version__  # noqa: F401
 
 
 def example_function(argument: str, keyword_argument: str = "default") -> str:
-    """Concatenate string arguments - an example function docstring.
+    """
+    Concatenate string arguments - an example function docstring.
 
     :param argument: An argument.
     :param keyword_argument: A keyword argument with a default value.

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.package_name}}/__init__.py
@@ -1,2 +1,12 @@
 """{{cookiecutter.package_name}} package."""
 from ._version import __version__  # noqa: F401
+
+
+def example_function(argument: str, keyword_argument: str = "default") -> None:
+    """An example function docstring.
+
+    :param argument: An argument.
+    :param keyword_argument: A keyword argument with a default value.
+    :returns: The concatenation of `argument` and `keyword_argument`.
+    """
+    return argument + keyword_argument


### PR DESCRIPTION
Would resolve #16 

Adds Sphinx documentation to template using `sphinx-autodoc2` to generate API documentation and using MyST parser to allow use of Markdown in docstrings (and documentation pages). Also sets up a few other extensions - [`sphinx.ext.intersphinx`](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html) for automatic links to other documentation with by default only the Python standard library index included, and [`sphinx.ext.viewcode`](https://www.sphinx-doc.org/en/master/usage/extensions/viewcode.html) to add links to source code. This is set up to use the [PyData Sphinx theme](https://pydata-sphinx-theme.readthedocs.io/en/stable/) which @samcunliffe recommeded on another project. A `tox` environment `docs` is added to simplify building documentation. 

This was mainly intended as a demonstration that it's possible to get Sphinx set up in a way which will easy for users to use and doesn't require much boilerplate for reference in discussion in #16. It's not clear yet if we would want to go with Sphinx rather than Mkdocs.

I also haven't yet added any default workflows to the template for building docs - ideally we'd want to make it easy to automatically deploy to GitHub pages but this would require some manual intervention from user to specify where GitHub pages site should be generated from. We could as an intermediate step just have a workflow for testing docs build, with a commented out step for subsequently doing deployment on pushes to `main` with instructions to user to do necessary configuration before uncommenting.

EDIT: Screenshot of what generated documentation website looks like

![image](https://github.com/UCL-ARC/python-tooling/assets/6746980/65f6830e-2486-4cf6-8b0c-1f227e1e0e83)

To dos
- [x] Add workflow for testing building documentation on pull-requests and pushes to main (for example https://github.com/UCL/neso-calibration/blob/main/.github/workflows/docs.yml)
- [ ] Add instructions of how to set up automatic deployment to GitHub pages in main README or as option in cookiecutter similar to `git init`
- [x] Add instructions for how to build documentation to template README.md
- [ ] Decide whether to include README.md content in docs
