### PR TITLE
Always ignore template at top level pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+exclude: ^{{cookiecutter.project_slug}}/
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.15
@@ -5,10 +6,6 @@ repos:
       - id: ruff
         args:
           - --config=pyproject.toml
-        exclude: |-
-          (?x)(
-            {{cookiecutter.project_slug}}/src/{{cookiecutter.package_name}}
-          )
       - id: ruff-format
         args:
           - --config=pyproject.toml
@@ -20,10 +17,6 @@ repos:
     rev: v0.23.1
     hooks:
       - id: toml-sort-fix
-        exclude: |-
-          (?x)(
-            {{cookiecutter.project_slug}}/pyproject.toml
-          )
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.8.0
     hooks:
@@ -32,19 +25,10 @@ repos:
           - --config-file=pyproject.toml
         additional_dependencies:
           - pytest
-        exclude: |-
-          (?x)(
-            {{cookiecutter.project_slug}}/src/{{cookiecutter.package_name}}|
-            {{cookiecutter.project_slug}}/tests
-          )
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
     hooks:
       - id: prettier
-        exclude: |-
-          (?x)(
-            {{cookiecutter.project_slug}}/.github/workflows/tests.yml
-          )
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:


### PR DESCRIPTION
We lint at the top level, and at the template level. It doesn't really make sense to template both, and some of the hooks get confused with the `cookiecutter` templating. Previously, we were ignoring some, but actually makes sense to ignore it all.

The downside is that locally it will be annoying to lint at the package level. But that is fine because CI with lint at the template level. Sometimes you may need to create a dummy project to fix the issue.