### PR TITLE
Revert "Correct uses of project_name in pyproject.toml"

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -49,7 +49,7 @@ urls.homepage = "https://github.com/{{cookiecutter.github_username}}/{{cookiecut
 [tool.coverage]
 report = {sort = "cover"}
 run = {branch = true, parallel = true, source = [
-    "{{cookiecutter.project_name}}",
+    "{{cookiecutter.project_slug}}",
 ]}
 paths.source = [
     "src",
@@ -88,7 +88,7 @@ lint.select = [
     "ALL",
 ]
 lint.isort.known-first-party = [
-    "{{cookiecutter.project_name}}",
+    "{{cookiecutter.project_slug | replace('-', '_')}}",
 ]
 lint.mccabe.max-complexity = 18
 lint.pep8-naming.classmethod-decorators = [


### PR DESCRIPTION
Reverts UCL-ARC/python-tooling#309. It turns out this was incorrect... source: a new package I just made. maybe at some point we should add some regression tests for the contents of `pyproject.toml`?