### PR TITLE
Start a utility libraries page.

### DIFF
--- a/docs/pages/utilities.md
+++ b/docs/pages/utilities.md
@@ -1,0 +1,26 @@
+---
+title: Utility libraries
+layout: default
+---
+
+# Utility libraries
+
+Useful packages for 'utility' functionality, normally we highlight these if
+we've found a library that we prefer to Python's builtin. You probably don't
+want to write these yourself but might need logging or a command-line interface.
+
+## Command-line interface
+
+| Name                                                        | Short description                                                              | 🚦  |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------ | :-: |
+| [typer](https://typer.tiangolo.com/)                        | A user-friendly and intuitive CLI system. Built on click.                      | 🟢  |
+| [click](https://click.palletsprojects.com/)                 | Makes nice-looking CLIs, and more configurable than argparse. Uses decorators. | 🟠  |
+| [argparse](https://docs.python.org/3/library/argparse.html) | Python's builtin CLI system uses object configuration.                         | 🟠  |
+| [optparse](https://docs.python.org/3/library/optparse.html) | A now-deprecated CLI system built into Python.                                 | 🔴  |
+
+## Logging
+
+| Name                                                      | Short description                                                    | 🚦  |
+| --------------------------------------------------------- | -------------------------------------------------------------------- | :-: |
+| [loguru](https://loguru.readthedocs.io/)                  | Simple and user-friendly with many nice features enabled by default. | 🟢  |
+| [logging](https://docs.python.org/3/library/logging.html) | Python's builtin logging framework. Needs some configuration.        | 🟠  |

--- a/docs/pages/utilities.md
+++ b/docs/pages/utilities.md
@@ -5,7 +5,7 @@ layout: default
 
 # Utility libraries
 
-Useful packages for 'utility' functionality, normally we highlight these if
+Useful packages for _utility_ functionality, normally we highlight these if
 we've found a library that we prefer to Python's builtin. You probably don't
 want to write these yourself but might need logging or a command-line interface.
 


### PR DESCRIPTION
Start a utilities page rather than solving #304 as-requested.

As I said in the ticket: I'm 👎 about adding these kinds of dependencies to our template. Not least because not everyone _needs_ a logger, but also because these choices feel out-of-scope.  We probably _should_ highlight libraries that we like and prefer to the builtins.

I've added my opinions, such as they are. Challenges are welcome.

## Closes
- #304.