### PR TITLE
Minor improvement to template sentence

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,8 +30,8 @@ makes it easier for others in the community to contribute to your package. Once
 _you_ get used to the structure makes it easier for you to contribute back to
 other packages.
 
-🍪 If you just want to get started with our recommendations, we have our own
-[template](https://github.com/UCL-ARC/python-tooling#using-this-template) that
+If you just want to get started with our recommendations, we have [our own
+Python package template](https://github.com/UCL-ARC/python-tooling#using-this-template) that
 lives in the same repository as these pages.
 
 Otherwise, each page on this site highlights recommended packages or services


### PR DESCRIPTION
- The 🍪 is a bit confusing out of context here, so remove
- "template" > "Python package template" as this might be the first time someone reads about a template, and otherwise they might wonder what it's for.