### PR TITLE
Split bindings by language

### DIFF
--- a/docs/pages/bindings.md
+++ b/docs/pages/bindings.md
@@ -5,10 +5,22 @@ layout: default
 
 # Bindings
 
-| Name                                                                                    | Short description                                                                              | 🚦  |
-| --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | :-: |
-| [Cython](https://cython.readthedocs.io/en/latest/src/userguide/wrapping_CPlusPlus.html) | C/C++ binding library with numpy array integration                                             | 🟢  |
-| [pyO3](https://github.com/PyO3/pyo3)                                                    | Straightforward bindings to rust with support for [packaging](https://github.com/PyO3/maturin) | 🟢  |
-| [ctypes](https://docs.python.org/3.8/library/ctypes.html)                               | Native python method for calling functions in shared C libraries                               | 🟠  |
-| [f2py](https://numpy.org/devdocs/f2py/f2py.getting-started.html)                        | Bindings to Fortran developed by numpy                                                         | 🟠  |
-| [pybind11](https://github.com/pybind/pybind11)                                          | Bindings to C++ with a steep learning curve                                                    | 🟠  |
+## C/C++
+
+| Name                                                                                    | Short description                                                | 🚦  |
+| --------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | :-: |
+| [Cython](https://cython.readthedocs.io/en/latest/src/userguide/wrapping_CPlusPlus.html) | C/C++ binding library with numpy array integration               | 🟢  |
+| [ctypes](https://docs.python.org/3.8/library/ctypes.html)                               | Native python method for calling functions in shared C libraries | 🟠  |
+| [pybind11](https://github.com/pybind/pybind11)                                          | Bindings to C++ with a steep learning curve                      | 🟠  |
+
+## Rust
+
+| Name                                 | Short description                                                                              | 🚦  |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------- | :-: |
+| [pyO3](https://github.com/PyO3/pyo3) | Straightforward bindings to rust with support for [packaging](https://github.com/PyO3/maturin) | 🟢  |
+
+## Fortran
+
+| Name                                                             | Short description                      | 🚦  |
+| ---------------------------------------------------------------- | -------------------------------------- | :-: |
+| [f2py](https://numpy.org/devdocs/f2py/f2py.getting-started.html) | Bindings to Fortran developed by numpy | 🟠  |


### PR DESCRIPTION
I think makes it clearer, and also with these new sub-categories we can stick to one 🟢 per sub-category?