### PR TITLE
Remove default issue assignees

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,9 +4,6 @@ description: Create a Report to Help us Improve
 title: "A one-line description of your problem"
 labels:
   - bug
-assignees:
-  - paddyroddy
-  - samcunliffe
 body:
   - id: describe
     type: textarea

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -4,9 +4,6 @@ description: How Can We Improve the Documentation
 title: "What needs improving in the documentation?"
 labels:
   - documentation
-assignees:
-  - paddyroddy
-  - samcunliffe
 body:
   - id: section
     type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,9 +4,6 @@ description: Suggest a Way to Improve This Project
 title: "Feature suggestion: What should be added?"
 labels:
   - enhancement
-assignees:
-  - paddyroddy
-  - samcunliffe
 body:
   - id: problem
     type: textarea

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -4,9 +4,6 @@ description: General Questions About Using the Cookiecutter Template
 title: "The title of your question."
 labels:
   - question
-assignees:
-  - paddyroddy
-  - samcunliffe
 body:
   - id: topic
     type: dropdown

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -4,9 +4,6 @@ description: A Task to be Completed
 title: "Task: What needs to be done?"
 labels:
   - task
-assignees:
-  - paddyroddy
-  - samcunliffe
 body:
   - id: section
     type: textarea

--- a/.github/ISSUE_TEMPLATE/website.yml
+++ b/.github/ISSUE_TEMPLATE/website.yml
@@ -4,9 +4,6 @@ description: How Can We Improve the Website
 title: "Website Improvement:"
 labels:
   - website
-assignees:
-  - paddyroddy
-  - samcunliffe
 body:
   - id: section
     type: textarea


### PR DESCRIPTION
My feeling is that adding default assignees to issues makes the project less welcoming for new (or existing) people to get involved with - if all issues are assigned I would certainly be wary of opening a PR to address them.