### PR TITLE
Drop `3.9` support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,8 +9,8 @@
   "initialise_git_repository": true,
   "deploy_docs_to_github_pages": false,
   "github_username": "{{cookiecutter.author_given_names.lower().replace(' ', '-')}}-{{cookiecutter.author_family_names.lower().replace(' ', '-')}}",
-  "min_python_version": ["3.9", "3.10", "3.11", "3.12"],
-  "max_python_version": ["3.12", "3.11", "3.10", "3.9"],
+  "min_python_version": ["3.10", "3.11", "3.12"],
+  "max_python_version": ["3.12", "3.11", "3.10"],
   "license": ["MIT", "BSD-3", "GPL-3.0"],
   "funder": "JBFC: The Joe Bloggs Funding Council",
   "__prompts__": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ overrides."tool.coverage.paths.source".inline_arrays = false
 legacy_tox_ini = """
     [gh-actions]
     python =
-        3.9: py39
         3.10: py310
         3.11: py311
         3.12: py312


### PR DESCRIPTION
Following the recent change on GitHub Actions https://github.com/actions/setup-python/issues/850 our tests are currently failing https://github.com/UCL-ARC/python-tooling/issues/359.

Previously we were following [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) which is why we never supported `3.8`. My suggestion is to drop `3.9` which means nothing else has to change.

The alternative is to do @dstansby's [suggestion](https://github.com/UCL-ARC/python-tooling/issues/359#issuecomment-2077127044), but I think this is low-key complicated when involving our `tox` setup too. Personally, I don't think it's worth it, and we should fix the tests ASAP.