### PR TITLE
Add all-contributors section to README

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,4 @@
+{
+  "projectName": "<insert the repo's name>",
+  "projectOwner": "<insert the repo's owner/orgs>"
+}

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,4 +1,4 @@
 {
-  "projectName": "<insert the repo's name>",
-  "projectOwner": "<insert the repo's owner/orgs>"
+  "projectName": "python-tooling",
+  "projectOwner": "UCL-ARC"
 }

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ Python packages with our recommended tooling set up and ready to go.
 [cookiecutter]: https://libraries.io/pypi/cookiecutter
 <!-- prettier-ignore-end -->
 
+## Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
 ## Using this template
 
 1.  Install [cookiecutter] in a Conda or `venv` environment (commented lines for


### PR DESCRIPTION
I'm following the instructions at https://allcontributors.org/docs/en/bot/installation. I think I already installed the GitHub app to this repository, so here's the config needed.

Fixes https://github.com/UCL-ARC/python-tooling/issues/372