### PR TITLE
Use list for `addopts`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [tool.pytest.ini_options]
-addopts = """
-    --color=yes
-    --import-mode=importlib
-    --verbose
-"""
+addopts = [
+    "--color=yes",
+    "--import-mode=importlib",
+    "--verbose",
+]
 testpaths = [
     "tests",
 ]

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -66,11 +66,11 @@ paths.source = [
 explicit_package_bases = true
 
 [tool.pytest.ini_options]
-addopts = """
-    --color=yes
-    --import-mode=importlib
-    --verbose
-"""
+addopts = [
+    "--color=yes",
+    "--import-mode=importlib",
+    "--verbose",
+]
 testpaths = [
     "tests",
 ]


### PR DESCRIPTION
From https://github.com/scientific-python/repo-review I learnt that `addopts` accepts TOML lists which are a lot more readable