### PR TITLE
Enable `show_submodules` option in MkDocs config

### DIFF
--- a/{{cookiecutter.project_slug}}/mkdocs.yml
+++ b/{{cookiecutter.project_slug}}/mkdocs.yml
@@ -50,6 +50,8 @@ plugins:
           docstring_style: google
           import:
             - "https://docs.python.org/3/objects.inv"
+          options:
+            show_submodules: true
           paths: [src]
   - include-markdown:
       opening_tag: "{!"


### PR DESCRIPTION
Fixes #365

Enables `plugins.mkdocstrings.handlers.python.options.show_submodules` option in `mkdocs.yml` configuration file for template so that [submodules of the top-level package are included in autogenerated API reference documentation by default.](https://stackoverflow.com/a/74237199)