### PR TITLE
Adding further instructions for GitHub pages docs deployment in hook

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -7,12 +7,13 @@ _EXIT_FAILURE = 1
 _EXIT_SUCCESS = 0
 
 
-def main(initialise_git_repository: str) -> int:
+def main(initialise_git_repository: str, deploy_docs_to_github_pages: str) -> int:
     """
     Create a git repository on generation of the project.
 
     Args:
         initialise_git_repository: Whether to initialise the repo
+        deploy_docs_to_github_pages: Whether to deploy built docs to GitHub Pages
 
     Returns:
         The return code of the process
@@ -65,7 +66,7 @@ def main(initialise_git_repository: str) -> int:
                 "-d '{{cookiecutter.project_short_description}}' "
                 "--public "
                 "-r origin "
-                "--source {{cookiecutter.project_slug}}"
+                "--source {{cookiecutter.project_slug}}\n"
             )
         except FileNotFoundError:
             # GitHub CLI isn't installed
@@ -77,15 +78,38 @@ def main(initialise_git_repository: str) -> int:
                 "https://docs.github.com/en/get-started/quickstart/create-a-repo.\n\n"
                 "Then run:\n\n"
                 "git remote add origin git@github.com:"
-                "{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}.git"
+                "{{cookiecutter.github_username}}/{{cookiecutter.project_slug}}.git\n"
             )
         except subprocess.CalledProcessError as e:
             # some other error
             print(f"There was an error with the GitHub CLI: {e.returncode}\n{e.stderr}")
             return _EXIT_FAILURE
+    if deploy_docs_to_github_pages == "True":
+        print(
+            "The 'Documentation' GitHub Actions workflow has been set up to push the "
+            "built HTML documentation to a branch gh-pages on pushes to main for "
+            "deploying as a GitHub Pages website. To allow the GitHub Actions bot to "
+            "push to the gh-pages branch you need to enable 'Read and write "
+            "permissions' under 'Workflow permissions' at\n\n"
+            "https://github.com/{{cookiecutter.github_username}}/"
+            "{{cookiecutter.project_slug}}/settings/actions\n\n"
+            "After the 'Documentation' workflow has successfully completed at least "
+            "once you will also need to configure the repository to deploy a GitHub "
+            "pages site from the content on the gh-pages branch by going to\n\n"
+            "https://github.com/{{cookiecutter.github_username}}/"
+            "{{cookiecutter.project_slug}}/settings/pages\n\n"
+            "and under 'Built and deployment' selecting 'Deploy from a branch' for "
+            "the 'Source' drop-down and 'gh-pages' for the 'Branch' drop-down, "
+            "leaving the branch path drop-down with its default value of '/ (root)."
+        )
 
     return _EXIT_SUCCESS
 
 
 if __name__ == "__main__":
-    sys.exit(main("{{ cookiecutter.initialise_git_repository }}"))
+    sys.exit(
+        main(
+            "{{ cookiecutter.initialise_git_repository }}",
+            "{{ cookiecutter.deploy_docs_to_github_pages }}",
+        )
+    )

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -100,7 +100,7 @@ def main(initialise_git_repository: str, deploy_docs_to_github_pages: str) -> in
             "{{cookiecutter.project_slug}}/settings/pages\n\n"
             "and under 'Built and deployment' selecting 'Deploy from a branch' for "
             "the 'Source' drop-down and 'gh-pages' for the 'Branch' drop-down, "
-            "leaving the branch path drop-down with its default value of '/ (root)."
+            "leaving the branch path drop-down with its default value of '/ (root)'."
         )
 
     return _EXIT_SUCCESS


### PR DESCRIPTION
Fixes #391 

Adds some text to be printed out in `post_gen_project.py` hook when `deploy_docs_to_github_pages` cookiecutter option is `True` to give instructions on how to complete set up of deployment of HTML documentation on GitHub Pages. 

Example output:

```
Initialized empty Git repository in /home/matt/projects/test-package/.git/
GitHub CLI detected, you can create a repo with the following:

gh repo create matt-graham/test-package -d 'A cookiecutter package with UCL ARC recommendations.' --public -r origin --source test-package

The 'Documentation' GitHub Actions workflow has been set up to push the built HTML 
documentation to a branch gh-pages on pushes to main for deploying as a GitHub 
Pages website. To allow the GitHub Actions bot to push to the gh-pages branch you 
need to enable 'Read and write permissions' under 'Workflow permissions' at

https://github.com/matt-graham/test-package/settings/actions

After the 'Documentation' workflow has successfully completed at least once you will 
also need to configure the repository to deploy a GitHub pages site from the content 
on the gh-pages branch by going to

https://github.com/matt-graham/test-package/settings/pages

and under 'Built and deployment' selecting 'Deploy from a branch' for the 'Source' 
drop-down and 'gh-pages' for the 'Branch' drop-down, leaving the branch path 
drop-down with its default value of '/ (root).
```