### PR TITLE
Automatically generate suggested email from supplied names in template

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,7 @@
 {
   "author_given_names": "Eva Lu",
   "author_family_names": "Ator",
-  "author_email": "eva.lu.ator@ucl.ac.uk",
+  "author_email": "{{'.'.join(cookiecutter.author_given_names.lower().split() + cookiecutter.author_family_names.lower().split())}}@ucl.ac.uk",
   "project_name": "Python Template",
   "project_slug": "{{cookiecutter.project_name.lower().replace(' ', '-').replace('_', '-')}}",
   "package_name": "{{cookiecutter.project_slug.replace('-', '_')}}",
@@ -16,7 +16,7 @@
   "__prompts__": {
     "author_given_names": "Given name(s) of package author",
     "author_family_names": "Family name(s) of package author",
-    "author_email": "Email address for package author - will be part of package metadata.",
+    "author_email": "Email address for package author - will be part of package metadata",
     "project_name": "Name of project - may contain spaces",
     "project_slug": "'Slugified' project name for use in URLs - dash-case recommended",
     "package_name": "Name for Python package - snake_case recommended",


### PR DESCRIPTION
Minor usability enhancement to template to auto-populate default for `author_email` based on supplied values for `author_given_names` and `author_family_names`, based on mapping names to lower case, joining with `.` and appending `@ucl.ac.uk`.

For example 
- `author_given_names = "Eval Lu"` and `author_family_names = "Ator"` will give suggested default `author_email = "eva.lu.ator@ucl.ac.uk"`,
- `author_given_names = "Patrick"` and `author_family_names = "Roddy"` will give suggested default  `author_email = "patrick.roddy@ucl.ac.uk"`.

I've stuck with joining full given names rather than extracting just initials with something like `[name[0] for name in cookiecutter.author_given_names.lower().split()]` even though using just initials seems more common in people's choices for 'friendly' UCL emails from a quick check of emails of contributors here, partly for simplicity but also as I guess manually removing additional characters from name is slightly easier than manually adding characters back in, but could switch this.