### PR TITLE
Fix `gh repo create` command for the Windows command prompt

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -63,7 +63,7 @@ def main(initialise_git_repository: str, deploy_docs_to_github_pages: str) -> in
                 "GitHub CLI detected, you can create a repo with the following:\n\n"
                 "gh repo create "
                 "{{cookiecutter.github_username}}/{{cookiecutter.project_slug}} "
-                "-d '{{cookiecutter.project_short_description}}' "
+                '-d "{{cookiecutter.project_short_description}}" '
                 "--public "
                 "-r origin "
                 "--source {{cookiecutter.project_slug}}\n"

--- a/tests/test_git_init.py
+++ b/tests/test_git_init.py
@@ -77,7 +77,7 @@ def test_initialisation_of_git_repo(
                 "GitHub CLI detected, you can create a repo with the following:\n\n"
                 f"gh repo create {project_config['github_username']}/"
                 f"{project_config['expected_repo_name']} -d "
-                f"'{project_config['project_short_description']}' --public -r "
+                f"\"{project_config['project_short_description']}\" --public -r "
                 f"origin --source {project_config['expected_repo_name']}"
                 in cookie.stdout
             )


### PR DESCRIPTION
In the *Festival of Digital Research and Scholarship* workshop: @llapira spotted that our command is broken on the Windows command prompt: needs double quotes otherwise it thinks this is five individual arguments.