### PR TITLE
Remove titles in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 ---
 name: Bug Report
 description: Create a Report to Help us Improve
-title: "A one-line description of your problem"
 labels:
   - bug
 body:

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,7 +1,6 @@
 ---
 name: Documentation
 description: How Can We Improve the Documentation
-title: "What needs improving in the documentation?"
 labels:
   - documentation
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,6 @@
 ---
 name: Feature Request
 description: Suggest a Way to Improve This Project
-title: "Feature suggestion: What should be added?"
 labels:
   - enhancement
 body:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,7 +1,6 @@
 ---
 name: Question
 description: General Questions About Using the Cookiecutter Template
-title: "The title of your question."
 labels:
   - question
 body:

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,7 +1,6 @@
 ---
 name: Task
 description: A Task to be Completed
-title: "Task: What needs to be done?"
 labels:
   - task
 body:

--- a/.github/ISSUE_TEMPLATE/website.yml
+++ b/.github/ISSUE_TEMPLATE/website.yml
@@ -1,7 +1,6 @@
 ---
 name: Website
 description: How Can We Improve the Website
-title: "Website Improvement:"
 labels:
   - website
 body:

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 ---
 name: Bug Report
 description: Create a Report to Help us Improve
-title: "A one-line description of your problem"
 labels:
   - bug
 body:

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,7 +1,6 @@
 ---
 name: Documentation
 description: How Can We Improve the Documentation
-title: "What needs improving in the documentation?"
 labels:
   - documentation
 body:

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,6 @@
 ---
 name: Feature Request
 description: Suggest a Way to Improve This Project
-title: "Feature suggestion: What should be added?"
 labels:
   - enhancement
 body:

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/question.yml
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/question.yml
@@ -1,7 +1,6 @@
 ---
 name: Question
 description: General Questions About Using {{cookiecutter.project_name}}
-title: "The title of your question."
 labels:
   - question
 body:


### PR DESCRIPTION
Fixes #420, which is essentially what #297 was trying to do.