### PR TITLE
Move scope/contributing guidelines to README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,3 @@
-This template and our [recommendation pages][website] were made by [research
-software engineers] at [UCL's Centre for Advanced Research Computing][UCL ARC].
-We made it with research software projects in mind, but whoever you are, we hope
-you find this useful!
-
-We are actively encouraging users to ask questions and start discussions in the
-[discussions tab] of this repository. Does something seem like it's broken?
-Please go ahead and [open an issue]!
-
-The [website] pages are open to contributions but they will need to be reviewed
-by a member or associate member of ARC. We might be slow to approve new tool
-suggestions (since we'll probably want to discuss them first) but don't let that
-put you off creating an issue.
-
 ## Development workflow
 
 To contribute a change, please:
@@ -30,10 +16,5 @@ To contribute a change, please:
 <!-- links here -->
 
 <!-- prettier-ignore-start -->
-[website]: https://github-pages.arc.ucl.ac.uk/python-tooling
-[UCL ARC]: https://ucl.ac.uk/arc
-[open an issue]: https://github.com/UCL-ARC/python-tooling/issues/new/choose
-[Discussions tab]: https://github.com/UCL-ARC/python-tooling/discussions
-[Research software engineers]: https://society-rse.org/about/history
 [@UCL-ARC/collaborations]: https://github.com/orgs/UCL-ARC/teams/collaborations
 <!-- prettier-ignore-end -->

--- a/README.md
+++ b/README.md
@@ -17,12 +17,26 @@ Python packages with our recommended tooling set up and ready to go.
 > package template (e.g., [`scikit-hep`](https://github.com/scikit-hep/cookie)),
 > we recommend using their template instead of this one.
 
+## Scope and contributing
+
+This project was created by [research software engineers] at [UCL's Centre for Advanced Research Computing][UCL ARC].
+We made it with our own research software projects in mind - we don't explicitly support external users, but whoever you are, we hope you might find it useful!
+
+This repository is open to contributions from all, but they will need be reviewed by a member or associate member of ARC.
+We might be slow to approve new tool suggestions (since we'll probably want to discuss them first) but don't let that put you off creating an issue or opening a pull request.
+See [CONTRIBUTING.md] for more details on how to contribute.
+
+We also accept (and encourage!) suggestions and bug reports from anyone.
+Use the [discussions tab] of this repository to ask questions or [open an issue] if something seems like it's broken.
+
 <!-- links here -->
 
 <!-- prettier-ignore-start -->
 [website]: https://github-pages.arc.ucl.ac.uk/python-tooling
 [UCL ARC]: https://ucl.ac.uk/arc
 [cookiecutter]: https://libraries.io/pypi/cookiecutter
+[open an issue]: https://github.com/UCL-ARC/python-tooling/issues/new/choose
+[discussions tab]: https://github.com/UCL-ARC/python-tooling/discussions
 <!-- prettier-ignore-end -->
 
 ## Contributors


### PR DESCRIPTION
~~This is what the scope of this repository has been in my head for a while, so I thought it worth getting it down in the README and seeing if others agree.~~

I think it's worth moving these bits from CONTRIBUTING.md to the README for visibility.