### PR TITLE
Create "Recommended libraries" category page with subpages.

### DIFF
--- a/docs/pages/libraries/bindings.md
+++ b/docs/pages/libraries/bindings.md
@@ -1,6 +1,7 @@
 ---
 title: Bindings
 layout: default
+parent: Recommended libraries
 ---
 
 # Bindings

--- a/docs/pages/libraries/clis.md
+++ b/docs/pages/libraries/clis.md
@@ -1,15 +1,10 @@
 ---
-title: Utility libraries
+title: Command-line interfaces
 layout: default
+parent: Recommended libraries
 ---
 
-# Utility libraries
-
-Useful packages for _utility_ functionality, normally we highlight these if
-we've found a library that we prefer to Python's builtin. You probably don't
-want to write these yourself but might need logging or a command-line interface.
-
-## Command-line interface
+# Command-line interfaces
 
 | Name                                                        | Short description                                                              | 🚦  |
 | ----------------------------------------------------------- | ------------------------------------------------------------------------------ | :-: |
@@ -18,14 +13,7 @@ want to write these yourself but might need logging or a command-line interface.
 | [argparse](https://docs.python.org/3/library/argparse.html) | Python's builtin CLI system uses object configuration.                         | 🟠  |
 | [optparse](https://docs.python.org/3/library/optparse.html) | A now-deprecated CLI system built into Python.                                 | 🔴  |
 
-## Logging
-
-| Name                                                      | Short description                                                    | 🚦  |
-| --------------------------------------------------------- | -------------------------------------------------------------------- | :-: |
-| [loguru](https://loguru.readthedocs.io/)                  | Simple and user-friendly with many nice features enabled by default. | 🟢  |
-| [logging](https://docs.python.org/3/library/logging.html) | Python's builtin logging framework. Needs some configuration.        | 🟠  |
-
-## User interface
+## Other useful tools for CLIs
 
 | Name                            | Short description       | 🚦  |
 | ------------------------------- | ----------------------- | :-: |

--- a/docs/pages/libraries/guis.md
+++ b/docs/pages/libraries/guis.md
@@ -1,6 +1,7 @@
 ---
 title: Graphical user interface toolkits
 layout: default
+parent: Recommended libraries
 ---
 
 # Graphical user interface toolkits

--- a/docs/pages/libraries/index.md
+++ b/docs/pages/libraries/index.md
@@ -9,6 +9,6 @@ has_children: true
 Python has a large ecosystem of packages and modules beyond what is built in to Python.
 Here is a list of libraries and toolkits that we've used in our projects, and can recommend (or might recommend that you avoid!).
 
-The libraries listed here are not really "tooling" in the sense that some projects will need some of the functionalities here, but it is project-dependent, so we don't include any of these in [our template]().
+The libraries listed here are not really "tooling" in the sense that some projects will need some of the functionalities here, but it is project-dependent, so we don't include any of these in [our template](https://github.com/UCL-ARC/python-tooling/blob/main/README.md#using-this-template).
 If you need some functionality discussed in this list, it's good practice to add the package to your project's dependencies list.
 To test it out, simply `pip install` into your enviroment and follow the package's "Getting Started" docs.

--- a/docs/pages/libraries/index.md
+++ b/docs/pages/libraries/index.md
@@ -1,0 +1,14 @@
+---
+title: Recommended libraries
+layout: default
+has_children: true
+---
+
+# Recommended libraries
+
+Python has a large ecosystem of packages and modules beyond what is built in to Python.
+Here is a list of libraries and toolkits that we've used in our projects, and can recommend (or might recommend that you avoid!).
+
+The libraries listed here are not really "tooling" in the sense that some projects will need some of the functionalities here, but it is project-dependent, so we don't include any of these in [our template]().
+If you need some functionality discussed in this list, it's good practice to add the package to your project's dependencies list.
+To test it out, simply `pip install` into your enviroment and follow the package's "Getting Started" docs.

--- a/docs/pages/libraries/jupyter-notebooks.md
+++ b/docs/pages/libraries/jupyter-notebooks.md
@@ -1,6 +1,7 @@
 ---
 title: Jupyter Notebooks
 layout: default
+parent: Recommended libraries
 ---
 
 # Jupyter notebooks

--- a/docs/pages/libraries/logging.md
+++ b/docs/pages/libraries/logging.md
@@ -1,0 +1,12 @@
+---
+title: Logging
+layout: default
+parent: Recommended libraries
+---
+
+# Logging
+
+| Name                                                      | Short description                                                    | 🚦  |
+| --------------------------------------------------------- | -------------------------------------------------------------------- | :-: |
+| [loguru](https://loguru.readthedocs.io/)                  | Simple and user-friendly with many nice features enabled by default. | 🟢  |
+| [logging](https://docs.python.org/3/library/logging.html) | Python's builtin logging framework. Needs some configuration.        | 🟠  |

--- a/docs/pages/libraries/parallel-async.md
+++ b/docs/pages/libraries/parallel-async.md
@@ -1,6 +1,7 @@
 ---
 title: Parallel and asynchronous processing
 layout: default
+parent: Recommended libraries
 ---
 
 # Parallel and asynchronous processing


### PR DESCRIPTION
As I'm one the who was blocking #373 and thumbs down-ing all over the place, here's a proposal to resolve #427.

## Resolves
- #427 

## Follows on from
- #328 
- #373 

## tl;dr of changes
This PR:
* Adds a parent "Recommended libraries" page with children: guis, parallel and async.
* Split's the non-obvious "Utility libraries" into clis and logging and moves them also under the parent.
* Adds some blurb to the parent page itself, which should be scrutinised for clarity and readability please!

## Choices:
I decide "Recommended libraries" rather than "Recommended modules" or "Utlility <anything>". Because a) some things in my brain's definition of the tools/not tools split are Python modules but still tool-ish and b) modules is a Python name but libraries feels _relatively_ language agnostic (to me, at least). I'm thinking of newcomers to Python.