### PR TITLE
conda → miniforge. Make anaconda explicitly red.

### DIFF
--- a/docs/pages/virtual.md
+++ b/docs/pages/virtual.md
@@ -5,14 +5,14 @@ layout: default
 
 # Virtual environments
 
-| Name                    | Short description                                                                                                                                                                         | 🚦  |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-: |
-| conda-forge [miniforge] | Installs, runs, and updates packages and their dependencies. A trusted sub-set of `conda` with the `conda-forge` channel.                                                                 | 🟢  |
-| [pipenv]                | Automatically creates and manages a virtualenv for your projects.                                                                                                                         | 🟠  |
-| [pyenv]                 | Lets you easily switch between multiple versions of Python.                                                                                                                               | 🟠  |
-| [virtualenv]            | Creates isolated Python environments, and offers more features than venv.                                                                                                                 | 🟠  |
+| Name                    | Short description                                                                                                                                                                                     | 🚦  |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-: |
+| conda-forge [miniforge] | Installs, runs, and updates packages and their dependencies. Uses `conda`, but with community maintained packages from `conda-forge` channel instead of commercially maintained packages.             | 🟢  |
+| [pipenv]                | Automatically creates and manages a virtualenv for your projects.                                                                                                                                     | 🟠  |
+| [pyenv]                 | Lets you easily switch between multiple versions of Python.                                                                                                                                           | 🟠  |
+| [virtualenv]            | Creates isolated Python environments, and offers more features than venv.                                                                                                                             | 🟠  |
 | [anaconda]              | Due to recent [licensing ambiguity][anaconda-problems], we recommend avoiding anaconda and many of the default channels. We recommend installing miniforge and sticking to the `conda-forge` channel. | 🔴  |
-| [venv]                  | Creates isolated Python environments.                                                                                                                                                     | 🔴  |
+| [venv]                  | Creates isolated Python environments.                                                                                                                                                                 | 🔴  |
 
 <!-- links here for a more readable table -->
 

--- a/docs/pages/virtual.md
+++ b/docs/pages/virtual.md
@@ -5,10 +5,13 @@ layout: default
 
 # Virtual environments
 
-| Name                                                     | Short description                                                         | 🚦  |
-| -------------------------------------------------------- | ------------------------------------------------------------------------- | :-: |
-| [Conda](https://docs.conda.io/projects/conda/en/stable/) | Installs, runs, and updates packages and their dependencies.              | 🟢  |
-| [pipenv](https://pipenv.pypa.io/en/latest/)              | Automatically creates and manages a virtualenv for your projects.         | 🟠  |
-| [pyenv](https://github.com/pyenv/pyenv)                  | Lets you easily switch between multiple versions of Python.               | 🟠  |
-| [virtualenv](https://virtualenv.pypa.io/en/latest/)      | Creates isolated Python environments, and offers more features than venv. | 🟠  |
-| [venv](https://docs.python.org/3/library/venv.html)      | Creates isolated Python environments.                                     | 🔴  |
+| Name                                                              | Short description                                                                                                                                                                         | 🚦  |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-: |
+| [conda-forge miniforge](https://github.com/conda-forge/miniforge) | Installs, runs, and updates packages and their dependencies. A trusted sub-set of `conda` with the `conda-forge` channel.                                                                 | 🟢  |
+| [pipenv](https://pipenv.pypa.io/en/latest/)                       | Automatically creates and manages a virtualenv for your projects.                                                                                                                         | 🟠  |
+| [pyenv](https://github.com/pyenv/pyenv)                           | Lets you easily switch between multiple versions of Python.                                                                                                                               | 🟠  |
+| [virtualenv](https://virtualenv.pypa.io/en/latest/)               | Creates isolated Python environments, and offers more features than venv.                                                                                                                 | 🟠  |
+| [venv](https://docs.python.org/3/library/venv.html)               | Creates isolated Python environments.                                                                                                                                                     | 🔴  |
+| [anaconda](https://www.anaconda.com/)                             | Due to recent [licensing ambiguity][anaconda-problems], we recommend avoiding anaconda and many of the default channels. We recommend miniforge or sticking to the `conda-forge` channel. | 🔴  |
+
+[anaconda-problems]: https://www.theregister.com/2024/08/08/anaconda_puts_the_squeeze_on/

--- a/docs/pages/virtual.md
+++ b/docs/pages/virtual.md
@@ -5,13 +5,21 @@ layout: default
 
 # Virtual environments
 
-| Name                                                              | Short description                                                                                                                                                                         | 🚦  |
-| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-: |
-| [conda-forge miniforge](https://github.com/conda-forge/miniforge) | Installs, runs, and updates packages and their dependencies. A trusted sub-set of `conda` with the `conda-forge` channel.                                                                 | 🟢  |
-| [pipenv](https://pipenv.pypa.io/en/latest/)                       | Automatically creates and manages a virtualenv for your projects.                                                                                                                         | 🟠  |
-| [pyenv](https://github.com/pyenv/pyenv)                           | Lets you easily switch between multiple versions of Python.                                                                                                                               | 🟠  |
-| [virtualenv](https://virtualenv.pypa.io/en/latest/)               | Creates isolated Python environments, and offers more features than venv.                                                                                                                 | 🟠  |
-| [venv](https://docs.python.org/3/library/venv.html)               | Creates isolated Python environments.                                                                                                                                                     | 🔴  |
-| [anaconda](https://www.anaconda.com/)                             | Due to recent [licensing ambiguity][anaconda-problems], we recommend avoiding anaconda and many of the default channels. We recommend miniforge or sticking to the `conda-forge` channel. | 🔴  |
+| Name                    | Short description                                                                                                                                                                         | 🚦  |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-: |
+| conda-forge [miniforge] | Installs, runs, and updates packages and their dependencies. A trusted sub-set of `conda` with the `conda-forge` channel.                                                                 | 🟢  |
+| [pipenv]                | Automatically creates and manages a virtualenv for your projects.                                                                                                                         | 🟠  |
+| [pyenv]                 | Lets you easily switch between multiple versions of Python.                                                                                                                               | 🟠  |
+| [virtualenv]            | Creates isolated Python environments, and offers more features than venv.                                                                                                                 | 🟠  |
+| [anaconda]              | Due to recent [licensing ambiguity][anaconda-problems], we recommend avoiding anaconda and many of the default channels. We recommend miniforge or sticking to the `conda-forge` channel. | 🔴  |
+| [venv]                  | Creates isolated Python environments.                                                                                                                                                     | 🔴  |
 
+<!-- links here for a more readable table -->
+
+[miniforge]: https://github.com/conda-forge/miniforge
+[pipenv]: https://pipenv.pypa.io/en/latest/
+[pyenv]: https://github.com/pyenv/pyenv
+[virtualenv]: https://virtualenv.pypa.io/en/latest/
+[anaconda]: https://www.anaconda.com/
 [anaconda-problems]: https://www.theregister.com/2024/08/08/anaconda_puts_the_squeeze_on/
+[venv]: https://commons.wikimedia.org/wiki/File:Devops-toolchain.svg

--- a/docs/pages/virtual.md
+++ b/docs/pages/virtual.md
@@ -11,12 +11,12 @@ layout: default
 | [pipenv]                | Automatically creates and manages a virtualenv for your projects.                                                                                                                         | 🟠  |
 | [pyenv]                 | Lets you easily switch between multiple versions of Python.                                                                                                                               | 🟠  |
 | [virtualenv]            | Creates isolated Python environments, and offers more features than venv.                                                                                                                 | 🟠  |
-| [anaconda]              | Due to recent [licensing ambiguity][anaconda-problems], we recommend avoiding anaconda and many of the default channels. We recommend miniforge or sticking to the `conda-forge` channel. | 🔴  |
+| [anaconda]              | Due to recent [licensing ambiguity][anaconda-problems], we recommend avoiding anaconda and many of the default channels. We recommend installing miniforge and sticking to the `conda-forge` channel. | 🔴  |
 | [venv]                  | Creates isolated Python environments.                                                                                                                                                     | 🔴  |
 
 <!-- links here for a more readable table -->
 
-[miniforge]: https://github.com/conda-forge/miniforge
+[miniforge]: https://conda-forge.org/download/
 [pipenv]: https://pipenv.pypa.io/en/latest/
 [pyenv]: https://github.com/pyenv/pyenv
 [virtualenv]: https://virtualenv.pypa.io/en/latest/

--- a/docs/pages/virtual.md
+++ b/docs/pages/virtual.md
@@ -22,4 +22,4 @@ layout: default
 [virtualenv]: https://virtualenv.pypa.io/en/latest/
 [anaconda]: https://www.anaconda.com/
 [anaconda-problems]: https://www.theregister.com/2024/08/08/anaconda_puts_the_squeeze_on/
-[venv]: https://commons.wikimedia.org/wiki/File:Devops-toolchain.svg
+[venv]: https://docs.python.org/3/library/venv.html


### PR DESCRIPTION
## Solves 
- #443. 

Deliberately does not address 
 - #419. 
 
Even if we decide to recommend `uv` over `conda-forge` we want to make the distinction.

Picky comments about language and clarity very gratefully received.