### PR TITLE
Native TOML support for `tox`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,9 +40,9 @@ jobs:
           cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
-        run: python -m pip install tox tox-gh-actions
+        run: python -m pip install tox tox-gh
 
       - name: Run tests
-        run: tox
+        run: tox run
         env:
-          OS: ${{ matrix.os }}
+          TOX_GH_MAJOR_MINOR: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,31 +38,27 @@ spaces_indent_inline_array = 4
 trailing_comma_inline_array = true
 overrides."project.classifiers".inline_arrays = false
 overrides."tool.coverage.paths.source".inline_arrays = false
+overrides."tool.tox.env_run_base.commands".inline_arrays = false
 
 [tool.tox]
-legacy_tox_ini = """
-    [gh-actions]
-    python =
-        3.11: py311
-        3.12: py312
-        3.13: py313
-
-    [gh-actions:env]
-    OS =
-        ubuntu-latest: linux
-        macos-latest: macos
-        windows-latest: windows
-
-    [testenv]
-    skip_install = true
-    description =
-        Test package creation
-    deps =
-        cookiecutter
-        pytest
-    commands =
-        pytest {posargs}
-
-    [tox]
-    env_list = py3{11,12,13}-{linux,macos,windows}
-"""
+env_list = [
+    "py311",
+    "py312",
+    "py313",
+]
+env_run_base = {commands = [
+    [
+        "pytest",
+        "{posargs}",
+    ],
+], deps = [
+    "cookiecutter",
+    "pytest",
+], description="Test package creation", skip_install=true}
+gh.python = {"3.11" = [
+    "py311",
+], "3.12" = [
+    "py312",
+], "3.13" = [
+    "py313",
+]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ env_run_base = {commands = [
 ], deps = [
     "cookiecutter",
     "pytest",
-], description="Test package creation", skip_install=true}
+], description = "Test package creation", skip_install = true}
 gh.python = {"3.11" = [
     "py311",
 ], "3.12" = [

--- a/tests/test_package_generation.py
+++ b/tests/test_package_generation.py
@@ -79,10 +79,11 @@ def test_package_generation(
 
     actual_files = get_all_files_folders(test_project_dir)
     # Filter out anything under specific directories to make comparison easier
-    actual_files = {
-        path
-        for path in actual_files
-        if not (str(path).startswith(".git/") or "__pycache__" in path.parts)
+    actual_files = actual_files - {
+        a
+        for a in actual_files
+        if len(a.parts) > 0
+        and (a.parts[0] == ".git" or "__pycache__" in a.parts or ".DS_Store" in a.parts)
     }
 
     assert actual_files == expected_files

--- a/tests/test_package_generation.py
+++ b/tests/test_package_generation.py
@@ -79,11 +79,10 @@ def test_package_generation(
 
     actual_files = get_all_files_folders(test_project_dir)
     # Filter out anything under specific directories to make comparison easier
-    actual_files = actual_files - {
-        a
-        for a in actual_files
-        if len(a.parts) > 0
-        and (a.parts[0] == ".git" or "__pycache__" in a.parts or ".DS_Store" in a.parts)
+    actual_files = {
+        path
+        for path in actual_files
+        if not (str(path).startswith(".git/") or "__pycache__" in path.parts)
     }
 
     assert actual_files == expected_files

--- a/tests/test_package_generation.py
+++ b/tests/test_package_generation.py
@@ -18,6 +18,10 @@ def get_all_files_folders(root_path: pathlib.Path) -> set[pathlib.Path]:
     for dirpath, _, filenames in os.walk(root_path):
         dirpath_path = pathlib.Path(dirpath).relative_to(root_path)
 
+        # Skip __pycache__ directories
+        if dirpath_path == "__pycache__":
+            continue
+
         # Add this directory
         file_set.update((dirpath_path,))
         # Add any files in it
@@ -76,8 +80,6 @@ def test_package_generation(
         pathlib.Path("src/cookiecutter_test/__init__.py"),
         pathlib.Path("tests"),
         pathlib.Path("tests/test_dummy.py"),
-        pathlib.Path("tests/__pycache__"),
-        pathlib.PosixPath("tests/__pycache__/test_dummy.cpython-*-pytest-*.pyc"),
     }
 
     actual_files = get_all_files_folders(test_project_dir)

--- a/tests/test_package_generation.py
+++ b/tests/test_package_generation.py
@@ -80,10 +80,10 @@ def test_package_generation(
 
     actual_files = get_all_files_folders(test_project_dir)
     # Filter out anything under specific directories to make comparison easier
-    actual_files = actual_files - {
-        a
-        for a in actual_files
-        if len(a.parts) > 0 and a.parts[0] in (".git", "__pycache__")
+    actual_files = {
+        path
+        for path in actual_files
+        if not str(path).startswith((".git/", "__pycache__/"))
     }
 
     assert actual_files == expected_files

--- a/tests/test_package_generation.py
+++ b/tests/test_package_generation.py
@@ -79,11 +79,10 @@ def test_package_generation(
 
     actual_files = get_all_files_folders(test_project_dir)
     # Filter out anything under specific directories to make comparison easier
-    actual_files = actual_files - {
+    actual_files = {
         a
         for a in actual_files
-        if len(a.parts) > 0
-        and (a.parts[0] == ".git" or "__pycache__" in a.parts or ".DS_Store" in a.parts)
+        if not (a.parts and (a.parts[0] == ".git" or "__pycache__" in a.parts))
     }
 
     assert actual_files == expected_files

--- a/tests/test_package_generation.py
+++ b/tests/test_package_generation.py
@@ -76,6 +76,8 @@ def test_package_generation(
         pathlib.Path("src/cookiecutter_test/__init__.py"),
         pathlib.Path("tests"),
         pathlib.Path("tests/test_dummy.py"),
+        pathlib.Path("tests/__pycache__"),
+        pathlib.Path("tests/__pycache__/").glob("test_dummy.cpython-*-pytest-*.pyc"),
     }
 
     actual_files = get_all_files_folders(test_project_dir)

--- a/tests/test_package_generation.py
+++ b/tests/test_package_generation.py
@@ -46,7 +46,6 @@ def test_package_generation(
     # Check main files and directories inside
     expected_files: set[pathlib.Path] = {
         pathlib.Path(),
-        pathlib.Path(".git"),
         pathlib.Path(".github"),
         pathlib.Path(".github/ISSUE_TEMPLATE"),
         pathlib.Path(".github/ISSUE_TEMPLATE/bug_report.yml"),

--- a/tests/test_package_generation.py
+++ b/tests/test_package_generation.py
@@ -44,7 +44,7 @@ def test_package_generation(
     assert test_project_dir.exists()
 
     # Check main files and directories inside
-    expected_files: set[pathlib.Path | pathlib.PurePath] = {
+    expected_files: set[pathlib.Path] = {
         pathlib.Path(),
         pathlib.Path(".git"),
         pathlib.Path(".github"),
@@ -77,7 +77,7 @@ def test_package_generation(
         pathlib.Path("tests"),
         pathlib.Path("tests/test_dummy.py"),
         pathlib.Path("tests/__pycache__"),
-        pathlib.PurePath("tests/__pycache__/test_dummy.cpython-*-pytest-*.pyc"),
+        pathlib.PosixPath("tests/__pycache__/test_dummy.cpython-*-pytest-*.pyc"),
     }
 
     actual_files = get_all_files_folders(test_project_dir)

--- a/tests/test_package_generation.py
+++ b/tests/test_package_generation.py
@@ -46,6 +46,7 @@ def test_package_generation(
     # Check main files and directories inside
     expected_files: set[pathlib.Path] = {
         pathlib.Path(),
+        pathlib.Path(".git"),
         pathlib.Path(".github"),
         pathlib.Path(".github/ISSUE_TEMPLATE"),
         pathlib.Path(".github/ISSUE_TEMPLATE/bug_report.yml"),

--- a/tests/test_package_generation.py
+++ b/tests/test_package_generation.py
@@ -18,10 +18,6 @@ def get_all_files_folders(root_path: pathlib.Path) -> set[pathlib.Path]:
     for dirpath, _, filenames in os.walk(root_path):
         dirpath_path = pathlib.Path(dirpath).relative_to(root_path)
 
-        # Skip __pycache__ directories
-        if dirpath_path == "__pycache__":
-            continue
-
         # Add this directory
         file_set.update((dirpath_path,))
         # Add any files in it
@@ -83,9 +79,11 @@ def test_package_generation(
     }
 
     actual_files = get_all_files_folders(test_project_dir)
-    # Filter out anything under .git/ to make comparison easier
+    # Filter out anything under specific directories to make comparison easier
     actual_files = actual_files - {
-        a for a in actual_files if len(a.parts) > 1 and a.parts[0] == ".git"
+        a
+        for a in actual_files
+        if len(a.parts) > 1 and a.parts[0] in (".git", "__pycache__")
     }
 
     assert actual_files == expected_files

--- a/tests/test_package_generation.py
+++ b/tests/test_package_generation.py
@@ -81,9 +81,7 @@ def test_package_generation(
     actual_files = get_all_files_folders(test_project_dir)
     # Filter out anything under specific directories to make comparison easier
     actual_files = actual_files - {
-        a
-        for a in actual_files
-        if len(a.parts) > 1 and a.parts[0] in (".git", "__pycache__")
+        a for a in actual_files if a.parts[0] in (".git", "__pycache__")
     }
 
     assert actual_files == expected_files

--- a/tests/test_package_generation.py
+++ b/tests/test_package_generation.py
@@ -46,7 +46,6 @@ def test_package_generation(
     # Check main files and directories inside
     expected_files: set[pathlib.Path] = {
         pathlib.Path(),
-        pathlib.Path(".git"),
         pathlib.Path(".github"),
         pathlib.Path(".github/ISSUE_TEMPLATE"),
         pathlib.Path(".github/ISSUE_TEMPLATE/bug_report.yml"),
@@ -80,10 +79,11 @@ def test_package_generation(
 
     actual_files = get_all_files_folders(test_project_dir)
     # Filter out anything under specific directories to make comparison easier
-    actual_files = {
-        path
-        for path in actual_files
-        if not str(path).startswith((".git/", "__pycache__/"))
+    actual_files = actual_files - {
+        a
+        for a in actual_files
+        if len(a.parts) > 0
+        and (a.parts[0] == ".git" or "__pycache__" in a.parts or ".DS_Store" in a.parts)
     }
 
     assert actual_files == expected_files

--- a/tests/test_package_generation.py
+++ b/tests/test_package_generation.py
@@ -44,7 +44,7 @@ def test_package_generation(
     assert test_project_dir.exists()
 
     # Check main files and directories inside
-    expected_files: set[pathlib.Path] = {
+    expected_files: set[pathlib.Path | pathlib.PurePath] = {
         pathlib.Path(),
         pathlib.Path(".git"),
         pathlib.Path(".github"),
@@ -77,7 +77,7 @@ def test_package_generation(
         pathlib.Path("tests"),
         pathlib.Path("tests/test_dummy.py"),
         pathlib.Path("tests/__pycache__"),
-        pathlib.Path("tests/__pycache__/").glob("test_dummy.cpython-*-pytest-*.pyc"),
+        pathlib.PurePath("tests/__pycache__/test_dummy.cpython-*-pytest-*.pyc"),
     }
 
     actual_files = get_all_files_folders(test_project_dir)

--- a/tests/test_package_generation.py
+++ b/tests/test_package_generation.py
@@ -81,7 +81,9 @@ def test_package_generation(
     actual_files = get_all_files_folders(test_project_dir)
     # Filter out anything under specific directories to make comparison easier
     actual_files = actual_files - {
-        a for a in actual_files if a.parts[0] in (".git", "__pycache__")
+        a
+        for a in actual_files
+        if len(a.parts) > 0 and a.parts[0] in (".git", "__pycache__")
     }
 
     assert actual_files == expected_files

--- a/{{cookiecutter.project_slug}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
           cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
-        run: python -m pip install tox tox-gh-actions
+        run: python -m pip install tox tox-gh
 
       - name: Test with tox
-        run: tox
+        run: tox run

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -131,12 +131,6 @@ env_run_base = {commands = [
 ], extras = [
     "test",
 ]}
-{%- for python_version in range(
-    cookiecutter.min_python_version | replace('3.', '') | int,
-    cookiecutter.max_python_version | replace('3.', '') | int + 1
-) %}
-gh.python."3.{{python_version}}" = ["py3{{python_version}}"]
-{%- endfor %}
 env.docs = {commands = [
     "mkdocs",
     "build",
@@ -144,3 +138,9 @@ env.docs = {commands = [
 ], extras = [
     "docs",
 ]}
+{%- for python_version in range(
+    cookiecutter.min_python_version | replace('3.', '') | int,
+    cookiecutter.max_python_version | replace('3.', '') | int + 1
+) %}
+gh.python."3.{{python_version}}" = ["py3{{python_version}}"]
+{%- endfor %}

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -119,7 +119,7 @@ env_list = [
     cookiecutter.min_python_version | replace('3.', '') | int,
     cookiecutter.max_python_version | replace('3.', '') | int + 1
 ) %}
-    "py3{{python_version}}"
+    "py3{{python_version}}",
 {%- endfor %}
 ]
 env_run_base = {commands = [

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -111,8 +111,8 @@ spaces_indent_inline_array = 4
 trailing_comma_inline_array = true
 overrides."project.classifiers".inline_arrays = false
 overrides."tool.coverage.paths.source".inline_arrays = false
-overrides."tool.tox.env_run_base.commands".inline_arrays = false
 overrides."tool.tox.env.docs.commands".inline_arrays = false
+overrides."tool.tox.env_run_base.commands".inline_arrays = false
 
 [tool.tox]
 env_list = [

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -112,6 +112,7 @@ trailing_comma_inline_array = true
 overrides."project.classifiers".inline_arrays = false
 overrides."tool.coverage.paths.source".inline_arrays = false
 overrides."tool.tox.env_run_base.commands".inline_arrays = false
+overrides."tool.tox.env.docs.commands".inline_arrays = false
 
 [tool.tox]
 env_list = [

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -111,36 +111,36 @@ spaces_indent_inline_array = 4
 trailing_comma_inline_array = true
 overrides."project.classifiers".inline_arrays = false
 overrides."tool.coverage.paths.source".inline_arrays = false
+overrides."tool.tox.env_run_base.commands".inline_arrays = false
 
 [tool.tox]
-legacy_tox_ini = """
-    [gh-actions]
-    python =
-    {%- for python_version in range(
-        cookiecutter.min_python_version | replace('3.', '') | int,
-        cookiecutter.max_python_version | replace('3.', '') | int + 1
-    ) %}
-        3.{{python_version}}: py3{{python_version}}
-    {%- endfor %}
-
-    [testenv]
-    commands =
-        pytest --cov --cov-report=xml
-    extras =
-        test
-
-    [testenv:docs]
-    commands =
-        mkdocs build --strict
-    extras =
-        docs
-
-    [tox]
-    env_list =
-    {%- for python_version in range(
-        cookiecutter.min_python_version | replace('3.', '') | int,
-        cookiecutter.max_python_version | replace('3.', '') | int + 1
-    ) %}
-        py3{{python_version}}
-    {%- endfor %}
-"""
+env_list = [
+{%- for python_version in range(
+    cookiecutter.min_python_version | replace('3.', '') | int,
+    cookiecutter.max_python_version | replace('3.', '') | int + 1
+) %}
+    "py3{{python_version}}"
+{%- endfor %}
+]
+env_run_base = {commands = [
+    [
+        "pytest",
+        "--cov",
+        "--cov-report=xml",
+    ],
+], extras = [
+    "test",
+]}
+{%- for python_version in range(
+    cookiecutter.min_python_version | replace('3.', '') | int,
+    cookiecutter.max_python_version | replace('3.', '') | int + 1
+) %}
+gh.python."3.{{python_version}}" = ["py3{{python_version}}"]
+{%- endfor %}
+env.docs = {commands = [
+    "mkdocs",
+    "build",
+    "--strict",
+], extras = [
+    "docs",
+]}


### PR DESCRIPTION
Fixes #455. In order to do this, have also switched from `tox-gh-actions` to `tox-gh`. Has been tested in https://github.com/astro-informatics/sleplet/pull/420, https://github.com/astro-informatics/sleplet/pull/421.

- [x] Will need to check if templating works correctly