### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,28 @@
+---
+name: Update Tag
+
+on:
+  release:
+    types:
+      - published
+
+env:
+  TAG_NAME: latest
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Update latest tag
+        run: |-
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git tag --force ${{ env.TAG_NAME }} ${{ github.sha }}
+          git push origin ${{ env.TAG_NAME }} --force


### PR DESCRIPTION
This will create a `latest` tag that will track the `release` tag, so that we can encourage users to use the `latest` tag, but when submitting a bug report we could use the actual version.

Note, if you don't follow SemVer then this wouldn't work. But that is kind of unavoidable.

Have tested on a dummy repo.