### PR TITLE
Change to `github.ref_name` for `latest` flag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,5 +24,5 @@ jobs:
         run: |-
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git tag --force ${{ env.TAG_NAME }} ${{ github.sha }}
+          git tag --force ${{ env.TAG_NAME }} ${{ github.ref_name }}
           git push origin ${{ env.TAG_NAME }} --force


### PR DESCRIPTION
I've changed `github.sha` to `github.ref_name`.

- `github.sha` points to the current commit SHA in the workflow
- `github.ref_name` will contain the tag name of the release

This ensures the latest tag points to the same commit as the release tag, rather than potentially pointing to a different commit that triggered the workflow. This is especially important if you create releases through the GitHub UI, where you might select an older commit to create the release from.