### PR TITLE
Fix missing `target-version` in `ruff`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ testpaths = [
 [tool.ruff]
 fix = true
 force-exclude = true
-target-version = "py310"
+target-version = "py311"
 lint.ignore = [
     "COM812", # trailing commas (ruff-format recommended)
     "D203", # no-blank-line-before-class

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ testpaths = [
 [tool.ruff]
 fix = true
 force-exclude = true
-target-version = "py39"
+target-version = "py310"
 lint.ignore = [
     "COM812", # trailing commas (ruff-format recommended)
     "D203", # no-blank-line-before-class


### PR DESCRIPTION
My bad, missed in https://github.com/UCL-ARC/python-tooling/pull/360