### PR TITLE
De-duplicate rennovate CI runs

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - "renovate/**"
   pull_request:
 
 jobs:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - "renovate/**"
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - "renovate/**"
   pull_request:
 
 jobs:


### PR DESCRIPTION
On recent rennovate PRs (e.g., https://github.com/UCL-ARC/python-tooling/pull/494), CI is duplicated because it's triggered on both `push` and `pull_request`. This removes running it on the `rennovate/**` branches to de-duplicate the CI.