### PR TITLE
Force test `pre-commit` config to be picked up

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -5,4 +5,7 @@
     ":assignAndReview(team:collaborations-python-tooling)",
     ":maintainLockFilesMonthly",
   ],
+  "pre-commit": {
+    fileMatch: ["tests/data/test_package_generation/.pre-commit-config.yaml"],
+  },
 }


### PR DESCRIPTION
Fixes #503. I want to fix this properly upstream, but this is a hack that we've used in MIRSG https://github.com/UCL-MIRSG/.github/blob/e61d159d27e610d165272c8ad5f1b743dabc4ff0/.renovaterc.json5#L7-L9. I think the regex that @renovatebot uses only looks for one folder deep, i.e. https://docs.renovatebot.com/modules/manager/pre-commit/#default-config.