### PR TITLE
Set `ignorePaths` to empty list

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -5,4 +5,5 @@
     ":assignAndReview(team:collaborations-python-tooling)",
     ":maintainLockFilesMonthly",
   ],
+  ignorePaths: [],
 }


### PR DESCRIPTION
Fixes #503. More general version of #502. We are using [config:best-practices](https://docs.renovatebot.com/presets-config/#configbest-practices) which inherits [config:recommended](https://docs.renovatebot.com/presets-config/#configrecommended). One of the settings that comes with that is [:ignoreModulesAndTests](https://docs.renovatebot.com/presets-default/#ignoremodulesandtests), which excludes folders like `**/test/**` - which is why our stuff is not being updated. By setting `ignorePaths` for this project only, we remove that problem.