### PR TITLE
Persist light theme on refresh 

### DIFF
--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -2,9 +2,22 @@
 
 <script>
   const toggleDarkMode = document.querySelector(".js-toggle-dark-mode");
-
   jtd.addEvent(toggleDarkMode, "click", function () {
     if (jtd.getTheme() === "light") {
+      jtd.setTheme("dark");
+      toggleDarkMode.textContent = "☼";
+      localStorage.setItem("theme", "dark");
+    } else {
+      jtd.setTheme("light");
+      toggleDarkMode.textContent = "☾";
+      localStorage.setItem("theme", "light");
+    }
+  });
+
+  // TODO: we can probably delete this (hacky workaround) if/when just-the-docs/#1223 is fixed.
+  // Meanwhile, we check each time if there is a theme written to local storage and obey it.
+  window.addEventListener("DOMContentLoaded", function () {
+    if (localStorage.getItem("theme") === "dark") {
       jtd.setTheme("dark");
       toggleDarkMode.textContent = "☼";
     } else {

--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -14,8 +14,9 @@
     }
   });
 
-  // TODO: we can probably delete this (hacky workaround) if/when just-the-docs/#1223 is fixed.
-  // Meanwhile, we check each time if there is a theme written to local storage and obey it.
+  /* TODO: we can probably delete this (hacky workaround) if/when just-the-docs/#1223 is fixed.
+   * Meanwhile, we check each time if there is a theme written to local storage and obey it.
+   */
   window.addEventListener("DOMContentLoaded", function () {
     if (localStorage.getItem("theme") === "dark") {
       jtd.setTheme("dark");


### PR DESCRIPTION
Fixes 

- #414

... using the workaround suggested in 

- https://github.com/just-the-docs/just-the-docs/issues/1223#issuecomment-1509704703.


Worth spending a bit of thought on whether we want more lines of my hacky JS code saving the theme to local storage, which we potentially can't delete until [jtd/#1223](https://github.com/just-the-docs/just-the-docs/issues/1223) is solved nicely upstream.

### Question:

Is it worth switching build system to something that supports theme toggling and inferring theme from the browser/os settings? It feels like it's the responsibility of the doc engine/doc theme. E.g. [Material for MkDocs supports it](https://github.com/UCL-ARC/mkdocs-rc-docs/blob/140e8fe5eef0379997af1b2eaaf396786bc006b8/mkdocs-project-dir/mkdocs.yml#L28).

That said, if you're happy with these lines, I am. 