### PR TITLE
Test package installation in temporary virtual environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[[tool.mypy.overrides]]
-ignore_missing_imports = true
-module = ["pytest_venv"]
-
 [tool.pytest.ini_options]
 addopts = [
     "--color=yes",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[[tool.mypy.overrides]]
+ignore_missing_imports = true
+module = ["pytest_venv"]
+
 [tool.pytest.ini_options]
 addopts = [
     "--color=yes",
@@ -54,6 +58,7 @@ env_run_base = {commands = [
 ], deps = [
     "cookiecutter",
     "pytest",
+    "pytest-venv",
 ], description = "Test package creation", skip_install = true}
 gh.python = {"3.11" = [
     "py311",

--- a/tests/test_package_generation.py
+++ b/tests/test_package_generation.py
@@ -110,10 +110,15 @@ def test_pip_installable(
     subprocess.run(  # noqa: S603
         [sys.executable, "-m", "venv", str(venv_path)], check=True
     )
+    # Location of virtual environment Python executable is OS dependent
+    if sys.platform == "win32":
+        venv_python = str(venv_path / "Scripts" / "python.exe")
+    else:
+        venv_python = str(venv_path / "bin" / "python")
     # Try to install package in virtual environment with pip
     pipinstall = subprocess.run(  # noqa: S603
         [
-            str(venv_path / "bin" / "python"),
+            venv_python,
             "-m",
             "pip",
             "install",

--- a/tests/test_package_generation.py
+++ b/tests/test_package_generation.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import shutil
 import subprocess
+import sys
 import typing
 
 import pytest
@@ -103,12 +104,16 @@ def test_pip_installable(
         "project_name": "Cookiecutter Test",
     }
     generate_package(config=test_config, path=tmp_path)
-
-    # Check project directory exists
     test_project_dir = tmp_path / "cookiecutter-test"
+    venv_path = test_project_dir / ".venv"
+    # Create temporary virtual environment
+    subprocess.run(  # noqa: S603
+        [sys.executable, "-m", "venv", str(venv_path)], check=True
+    )
+    # Try to install package in virtual environment with pip
     pipinstall = subprocess.run(  # noqa: S603
-        [  # noqa: S607
-            "python",
+        [
+            str(venv_path / "bin" / "python"),
             "-m",
             "pip",
             "install",

--- a/tests/test_package_generation.py
+++ b/tests/test_package_generation.py
@@ -8,7 +8,7 @@ import subprocess
 import typing
 
 import pytest
-import pytest_venv
+import pytest_venv  # type: ignore[import-not-found]
 
 
 def get_all_files_folders(root_path: pathlib.Path) -> set[pathlib.Path]:

--- a/tests/test_package_generation.py
+++ b/tests/test_package_generation.py
@@ -5,10 +5,10 @@ import os
 import pathlib
 import shutil
 import subprocess
-import sys
 import typing
 
 import pytest
+import pytest_venv
 
 
 def get_all_files_folders(root_path: pathlib.Path) -> set[pathlib.Path]:
@@ -95,6 +95,7 @@ def test_package_generation(
 
 def test_pip_installable(
     tmp_path: pathlib.Path,
+    venv: pytest_venv.VirtualEnvironment,
     generate_package: typing.Callable,
 ) -> None:
     """Test generated package is pip installable."""
@@ -105,20 +106,10 @@ def test_pip_installable(
     }
     generate_package(config=test_config, path=tmp_path)
     test_project_dir = tmp_path / "cookiecutter-test"
-    venv_path = test_project_dir / ".venv"
-    # Create temporary virtual environment
-    subprocess.run(  # noqa: S603
-        [sys.executable, "-m", "venv", str(venv_path)], check=True
-    )
-    # Location of virtual environment Python executable is OS dependent
-    if sys.platform == "win32":
-        venv_python = str(venv_path / "Scripts" / "python.exe")
-    else:
-        venv_python = str(venv_path / "bin" / "python")
     # Try to install package in virtual environment with pip
     pipinstall = subprocess.run(  # noqa: S603
         [
-            venv_python,
+            venv.python,
             "-m",
             "pip",
             "install",


### PR DESCRIPTION
Resolves #516 

Creates a virtual environment in temporary package directory and tests package installation in there rather than installing in parent environment tests are run from.

Calling `pip install` command by directly referencing Python executable in created virtual environment seems to work in terms of ensuring package is installed in `site-packages` of temporary virtual environment rather than parent environment (at least I no longer see a `cookiecutter-test` entry when running `pip list` after running tests) and it seemed non trivial to `source` the virtual environment script with `subprocess.run`.