### PR TITLE
Add label to theme-switcher button.

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -13,15 +13,15 @@ GEM
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
     ffi (1.17.2)
-    ffi (1.17.2-aarch64-linux)
+    ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
-    ffi (1.17.2-arm-linux)
+    ffi (1.17.2-arm-linux-gnu)
     ffi (1.17.2-arm-linux-musl)
     ffi (1.17.2-arm64-darwin)
-    ffi (1.17.2-x86-linux)
+    ffi (1.17.2-x86-linux-gnu)
     ffi (1.17.2-x86-linux-musl)
     ffi (1.17.2-x86_64-darwin)
-    ffi (1.17.2-x86_64-linux)
+    ffi (1.17.2-x86_64-linux-gnu)
     ffi (1.17.2-x86_64-linux-musl)
     forwardable-extended (2.6.0)
     google-protobuf (4.30.2)
@@ -100,33 +100,33 @@ GEM
     sass-embedded (1.87.0)
       google-protobuf (~> 4.30)
       rake (>= 13)
-    sass-embedded (1.87.0-aarch64-linux)
-      google-protobuf (~> 4.30)
     sass-embedded (1.87.0-aarch64-linux-android)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.87.0-aarch64-linux-gnu)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-aarch64-linux-musl)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-aarch64-mingw-ucrt)
       google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-arm-linux)
-      google-protobuf (~> 4.30)
     sass-embedded (1.87.0-arm-linux-androideabi)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.87.0-arm-linux-gnueabihf)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-arm-linux-musleabihf)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-arm64-darwin)
       google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-riscv64-linux)
-      google-protobuf (~> 4.30)
     sass-embedded (1.87.0-riscv64-linux-android)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.87.0-riscv64-linux-gnu)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-riscv64-linux-musl)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-x86_64-darwin)
       google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-x86_64-linux)
-      google-protobuf (~> 4.30)
     sass-embedded (1.87.0-x86_64-linux-android)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.87.0-x86_64-linux-gnu)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-x86_64-linux-musl)
       google-protobuf (~> 4.30)
@@ -137,31 +137,31 @@ GEM
 
 PLATFORMS
   aarch64-linux
-  aarch64-linux
   aarch64-linux-android
+  aarch64-linux-gnu
   aarch64-linux-musl
   aarch64-mingw-ucrt
-  arm-linux
-  arm-linux
   arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
   arm-linux-musl
   arm-linux-musleabihf
   arm64-darwin
-  riscv64-linux
   riscv64-linux-android
+  riscv64-linux-gnu
   riscv64-linux-musl
   ruby
   x86-cygwin
   x86-linux
-  x86-linux
   x86-linux-android
+  x86-linux-gnu
   x86-linux-musl
   x86-mingw-ucrt
   x86_64-cygwin
   x86_64-darwin
   x86_64-linux
-  x86_64-linux
   x86_64-linux-android
+  x86_64-linux-gnu
   x86_64-linux-musl
 
 DEPENDENCIES

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -13,15 +13,15 @@ GEM
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
     ffi (1.17.2)
-    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux)
     ffi (1.17.2-aarch64-linux-musl)
-    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux)
     ffi (1.17.2-arm-linux-musl)
     ffi (1.17.2-arm64-darwin)
-    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux)
     ffi (1.17.2-x86-linux-musl)
     ffi (1.17.2-x86_64-darwin)
-    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux)
     ffi (1.17.2-x86_64-linux-musl)
     forwardable-extended (2.6.0)
     google-protobuf (4.30.2)
@@ -100,33 +100,33 @@ GEM
     sass-embedded (1.87.0)
       google-protobuf (~> 4.30)
       rake (>= 13)
-    sass-embedded (1.87.0-aarch64-linux-android)
+    sass-embedded (1.87.0-aarch64-linux)
       google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-aarch64-linux-gnu)
+    sass-embedded (1.87.0-aarch64-linux-android)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-aarch64-linux-musl)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-aarch64-mingw-ucrt)
       google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-arm-linux-androideabi)
+    sass-embedded (1.87.0-arm-linux)
       google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-arm-linux-gnueabihf)
+    sass-embedded (1.87.0-arm-linux-androideabi)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-arm-linux-musleabihf)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-arm64-darwin)
       google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-riscv64-linux-android)
+    sass-embedded (1.87.0-riscv64-linux)
       google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-riscv64-linux-gnu)
+    sass-embedded (1.87.0-riscv64-linux-android)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-riscv64-linux-musl)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-x86_64-darwin)
       google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-x86_64-linux-android)
+    sass-embedded (1.87.0-x86_64-linux)
       google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-x86_64-linux-gnu)
+    sass-embedded (1.87.0-x86_64-linux-android)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-x86_64-linux-musl)
       google-protobuf (~> 4.30)
@@ -137,31 +137,31 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  aarch64-linux
   aarch64-linux-android
-  aarch64-linux-gnu
   aarch64-linux-musl
   aarch64-mingw-ucrt
+  arm-linux
+  arm-linux
   arm-linux-androideabi
-  arm-linux-gnu
-  arm-linux-gnueabihf
   arm-linux-musl
   arm-linux-musleabihf
   arm64-darwin
+  riscv64-linux
   riscv64-linux-android
-  riscv64-linux-gnu
   riscv64-linux-musl
   ruby
   x86-cygwin
   x86-linux
+  x86-linux
   x86-linux-android
-  x86-linux-gnu
   x86-linux-musl
   x86-mingw-ucrt
   x86_64-cygwin
   x86_64-darwin
   x86_64-linux
+  x86_64-linux
   x86_64-linux-android
-  x86_64-linux-gnu
   x86_64-linux-musl
 
 DEPENDENCIES

--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -1,4 +1,6 @@
-<button class="btn js-toggle-dark-mode">☼</button>
+<button class="btn js-toggle-dark-mode" aria-label="Switch to light mode">
+  ☼
+</button>
 
 <script>
   const toggleDarkMode = document.querySelector(".js-toggle-dark-mode");
@@ -6,10 +8,12 @@
     if (jtd.getTheme() === "light") {
       jtd.setTheme("dark");
       toggleDarkMode.textContent = "☼";
+      toggleDarkMode.ariaLabel = "Switch to light mode";
       localStorage.setItem("theme", "dark");
     } else {
       jtd.setTheme("light");
       toggleDarkMode.textContent = "☾";
+      toggleDarkMode.ariaLabel = "Switch to dark mode";
       localStorage.setItem("theme", "light");
     }
   });


### PR DESCRIPTION
Fixes 
- #537 

as suggested by @jamesprime by adding an [aria label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label) to labelless button. Confirmed with macOS's "VoiceOver" screen reader...

![Screenshot 2025-06-03 at 13 25 10](https://github.com/user-attachments/assets/93c86456-feca-4ff4-91d4-4b8c4afd5797)

---

As with the ☼ / ☾ it's a bit WET because it needs declaring and then the same lines appear in the switch conditional.