### PR TITLE
fix: improve contrast for all links, button and label text

### DIFF
--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -4,14 +4,21 @@
 
 <script>
   const toggleDarkMode = document.querySelector(".js-toggle-dark-mode");
+
+  const setHtmlThemeAttr = (theme) => {
+    document.documentElement.setAttribute("data-theme", theme);
+  };
+
   jtd.addEvent(toggleDarkMode, "click", function () {
     if (jtd.getTheme() === "light") {
       jtd.setTheme("dark");
+      setHtmlThemeAttr("dark");
       toggleDarkMode.textContent = "☼";
       toggleDarkMode.ariaLabel = "Switch to light mode";
       localStorage.setItem("theme", "dark");
     } else {
       jtd.setTheme("light");
+      setHtmlThemeAttr("light");
       toggleDarkMode.textContent = "☾";
       toggleDarkMode.ariaLabel = "Switch to dark mode";
       localStorage.setItem("theme", "light");
@@ -22,12 +29,9 @@
    * Meanwhile, we check each time if there is a theme written to local storage and obey it.
    */
   window.addEventListener("DOMContentLoaded", function () {
-    if (localStorage.getItem("theme") === "dark") {
-      jtd.setTheme("dark");
-      toggleDarkMode.textContent = "☼";
-    } else {
-      jtd.setTheme("light");
-      toggleDarkMode.textContent = "☾";
-    }
+    const theme = localStorage.getItem("theme") === "dark" ? "dark" : "light";
+    jtd.setTheme(theme);
+    setHtmlThemeAttr(theme);
+    toggleDarkMode.textContent = theme === "dark" ? "☼" : "☾";
   });
 </script>

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -28,3 +28,41 @@ div.site-logo {
   width: 100%;
   color: $body-text-color;
 }
+
+/* Dark mode link styles */
+html[data-theme="dark"] {
+  .main-header a,
+  .main-header button,
+  .side-bar a {
+    color: $link-color-dark;
+  }
+
+  main a,
+  footer a {
+    color: $link-color-dark;
+    text-decoration: underline;
+    text-decoration-color: $link-color-dark;
+    text-decoration-thickness: 1px;
+    transition:
+      text-decoration-thickness 0.2s ease-in-out,
+      text-underline-offset 0.2s ease-in-out;
+  }
+
+  main a:hover,
+  footer a:hover {
+    text-decoration-color: $link-color-dark;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 3px;
+  }
+}
+
+/* Label colors */
+main {
+  .label-green {
+    background-color: $label-success-bg;
+  }
+
+  .label-red {
+    background-color: $label-error-bg;
+  }
+}

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -29,7 +29,7 @@ div.site-logo {
   color: $body-text-color;
 }
 
-/* Dark mode link styles */
+//Dark mode link styles
 html[data-theme="dark"] {
   .main-header a,
   .main-header button,
@@ -56,7 +56,7 @@ html[data-theme="dark"] {
   }
 }
 
-/* Label colors */
+//Label colors
 main {
   .label-green {
     background-color: $label-success-bg;

--- a/docs/_sass/custom/setup.scss
+++ b/docs/_sass/custom/setup.scss
@@ -1,0 +1,9 @@
+// Color palette
+$blue-400: #4da6ff;
+$green-700: #00755c;
+$red-600: #d13c3c;
+
+// Semantic mappings
+$link-color-dark: $blue-400;
+$label-success-bg: $green-700;
+$label-error-bg: $red-600;


### PR DESCRIPTION
This PR improves dark mode accessibility to meet the minimum contrast ratio of 4.5:1.

**Issues**

- Link text and underline colors in dark mode didn’t meet the 4.5:1 contrast ratio requirement.
- Hover state on links was barely noticeable due to minimal styling difference.
- Green and red labels didn’t provide enough contrast with white text.
- The data-theme="dark" attribute was not consistently applied, causing dark mode styles to fail.

**Changes**

- Updated dark mode link and underline colors for better contrast and visibility
- Added hover underline animation (+1px thickness and offset)
- Improved label background colors for accessibility
- Introduced _sass/custom/variables.scss with named tokens ($link-color-dark, etc.)
- Explicitly set data-theme attribute on <html> based on a selected theme

Closes #535

Verified links contrast with the WCAG contrast checker tool