### PR TITLE
Stop `vale` failing for forked contributions that don't touch prose.

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -71,5 +71,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          filter_mode: nofilter
+          filter_mode: diff_context
           reporter: github-check

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 </div>
 <!-- markdownlint-restore -->
 
-This is quite a weasly sentence, I'm fairly sure that this might maybe work, maybe.
-
 This repository collects the [UCL ARC] recommendations for a research software
 project in Python. It contains a template for new Python packages and a
 [website] documenting our recommendations. We've turned on

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 </div>
 <!-- markdownlint-restore -->
 
+This is quite a weasly sentence, I'm fairly sure that this might maybe work, maybe.
+
 This repository collects the [UCL ARC] recommendations for a research software
 project in Python. It contains a template for new Python packages and a
 [website] documenting our recommendations. We've turned on


### PR DESCRIPTION
Relates to 
- #549

(i.e. the prose lint failure for pull requests from forked repositories).
Should improve the quality of life of external contributing devs.

This change _only_ annotates the diff introduced by a PR. So #549 will still be a bug for external contributors who write a lot of prose. But for technical contributions, at least, we avoid the 10 annotations limit.