### PR TITLE
Add a Makefile for Ruby/`bundle`/Jekyll commands that I always forget.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,11 +75,9 @@ Pages all live in the `docs/pages` sub-directory, and are written in markdown.
 To build the webpage locally (for testing)
 
 1. [Install jekyll]
-2. Run `bundle install` from the `docs/` directory of this repository to
-   install dependencies.
-3. Run `bundle exec jekyll serve` from the root directory of this repository.
-   This should fire up a local web server and tell you its address. By default
-   the server will automatically refresh the HTML pages if any changes are made
+2. Run `make serve` from the `docs/` directory of this repository to
+   install dependencies and start a local web server.
+   The server will automatically refresh the HTML pages if any changes are made
    to the markdown sources.
 
 See the [jekyll docs] for more info.

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -13,15 +13,15 @@ GEM
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
     ffi (1.17.2)
-    ffi (1.17.2-aarch64-linux)
+    ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
-    ffi (1.17.2-arm-linux)
+    ffi (1.17.2-arm-linux-gnu)
     ffi (1.17.2-arm-linux-musl)
     ffi (1.17.2-arm64-darwin)
-    ffi (1.17.2-x86-linux)
+    ffi (1.17.2-x86-linux-gnu)
     ffi (1.17.2-x86-linux-musl)
     ffi (1.17.2-x86_64-darwin)
-    ffi (1.17.2-x86_64-linux)
+    ffi (1.17.2-x86_64-linux-gnu)
     ffi (1.17.2-x86_64-linux-musl)
     forwardable-extended (2.6.0)
     google-protobuf (4.30.2)
@@ -100,33 +100,33 @@ GEM
     sass-embedded (1.87.0)
       google-protobuf (~> 4.30)
       rake (>= 13)
-    sass-embedded (1.87.0-aarch64-linux)
-      google-protobuf (~> 4.30)
     sass-embedded (1.87.0-aarch64-linux-android)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.87.0-aarch64-linux-gnu)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-aarch64-linux-musl)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-aarch64-mingw-ucrt)
       google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-arm-linux)
-      google-protobuf (~> 4.30)
     sass-embedded (1.87.0-arm-linux-androideabi)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.87.0-arm-linux-gnueabihf)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-arm-linux-musleabihf)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-arm64-darwin)
       google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-riscv64-linux)
-      google-protobuf (~> 4.30)
     sass-embedded (1.87.0-riscv64-linux-android)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.87.0-riscv64-linux-gnu)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-riscv64-linux-musl)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-x86_64-darwin)
       google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-x86_64-linux)
-      google-protobuf (~> 4.30)
     sass-embedded (1.87.0-x86_64-linux-android)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.87.0-x86_64-linux-gnu)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-x86_64-linux-musl)
       google-protobuf (~> 4.30)
@@ -137,31 +137,31 @@ GEM
 
 PLATFORMS
   aarch64-linux
-  aarch64-linux
   aarch64-linux-android
+  aarch64-linux-gnu
   aarch64-linux-musl
   aarch64-mingw-ucrt
-  arm-linux
-  arm-linux
   arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
   arm-linux-musl
   arm-linux-musleabihf
   arm64-darwin
-  riscv64-linux
   riscv64-linux-android
+  riscv64-linux-gnu
   riscv64-linux-musl
   ruby
   x86-cygwin
   x86-linux
-  x86-linux
   x86-linux-android
+  x86-linux-gnu
   x86-linux-musl
   x86-mingw-ucrt
   x86_64-cygwin
   x86_64-darwin
   x86_64-linux
-  x86_64-linux
   x86_64-linux-android
+  x86_64-linux-gnu
   x86_64-linux-musl
 
 DEPENDENCIES

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -13,15 +13,15 @@ GEM
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
     ffi (1.17.2)
-    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux)
     ffi (1.17.2-aarch64-linux-musl)
-    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux)
     ffi (1.17.2-arm-linux-musl)
     ffi (1.17.2-arm64-darwin)
-    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux)
     ffi (1.17.2-x86-linux-musl)
     ffi (1.17.2-x86_64-darwin)
-    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux)
     ffi (1.17.2-x86_64-linux-musl)
     forwardable-extended (2.6.0)
     google-protobuf (4.30.2)
@@ -100,33 +100,33 @@ GEM
     sass-embedded (1.87.0)
       google-protobuf (~> 4.30)
       rake (>= 13)
-    sass-embedded (1.87.0-aarch64-linux-android)
+    sass-embedded (1.87.0-aarch64-linux)
       google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-aarch64-linux-gnu)
+    sass-embedded (1.87.0-aarch64-linux-android)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-aarch64-linux-musl)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-aarch64-mingw-ucrt)
       google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-arm-linux-androideabi)
+    sass-embedded (1.87.0-arm-linux)
       google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-arm-linux-gnueabihf)
+    sass-embedded (1.87.0-arm-linux-androideabi)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-arm-linux-musleabihf)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-arm64-darwin)
       google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-riscv64-linux-android)
+    sass-embedded (1.87.0-riscv64-linux)
       google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-riscv64-linux-gnu)
+    sass-embedded (1.87.0-riscv64-linux-android)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-riscv64-linux-musl)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-x86_64-darwin)
       google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-x86_64-linux-android)
+    sass-embedded (1.87.0-x86_64-linux)
       google-protobuf (~> 4.30)
-    sass-embedded (1.87.0-x86_64-linux-gnu)
+    sass-embedded (1.87.0-x86_64-linux-android)
       google-protobuf (~> 4.30)
     sass-embedded (1.87.0-x86_64-linux-musl)
       google-protobuf (~> 4.30)
@@ -137,31 +137,31 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  aarch64-linux
   aarch64-linux-android
-  aarch64-linux-gnu
   aarch64-linux-musl
   aarch64-mingw-ucrt
+  arm-linux
+  arm-linux
   arm-linux-androideabi
-  arm-linux-gnu
-  arm-linux-gnueabihf
   arm-linux-musl
   arm-linux-musleabihf
   arm64-darwin
+  riscv64-linux
   riscv64-linux-android
-  riscv64-linux-gnu
   riscv64-linux-musl
   ruby
   x86-cygwin
   x86-linux
+  x86-linux
   x86-linux-android
-  x86-linux-gnu
   x86-linux-musl
   x86-mingw-ucrt
   x86_64-cygwin
   x86_64-darwin
   x86_64-linux
+  x86_64-linux
   x86_64-linux-android
-  x86_64-linux-gnu
   x86_64-linux-musl
 
 DEPENDENCIES

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,4 +1,5 @@
 SHELL := /bin/bash
+.PHONY: help serve build install clean check
 
 help: ## Show this help
 	@echo

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,23 @@
+SHELL := /bin/bash
+
+help: ## Show this help
+	@echo
+	@grep -E '^[a-zA-Z_0-9-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%s\033[0m|%s\n", $$1, $$2}' \
+        | column -t -s '|'
+	@echo
+
+serve: install ## Start a local server and serve the site
+	bundle exec jekyll serve
+
+build: install ## Build the site
+	bundle exec jekyll build
+
+install: check ## Pull all jekyll dependencies
+	bundle install
+
+clean: ## Remove build files
+	rm -rf _site
+
+check: ## Check ruby (bundle) is installed
+	@command -v bundle &> /dev/null || { echo >&2 "Please install ruby >= 2.7 to use Jekyll"; exit 1; }


### PR DESCRIPTION
I can never remember how to build the pages. Perhaps `make` helps? Certainly, it will positively affect all the carbon I'm wasting by Googling this: Every. Single. Time.

With no arguments it shows help:
```sh
❯ make

help     Show this help
serve    Start a local server and serve the site
build    Build the site
install  Pull all jekyll dependencies
clean    Remove build files
check    Check ruby (bundle) is installed
```

And `make serve` does what 90% of developers are going to want for checking local changes.

Inspired by (and a little bit stolen from) @t-young31 and @milanmlft (who are both very cool).