### PR TITLE
Clean up headings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,11 @@ Python packages with our recommended tooling set up and ready to go.
 > package template (e.g., [`scikit-hep`](https://github.com/scikit-hep/cookie)),
 > we recommend using their template instead of this one.
 
-## Tutorial
+
+## Using our Python package template
 
 Some quick instructions for using our template are below.
-We also have a [tutorial](./tutorial.md) that has been presented in a couple of workshops aimed at researchers at UCL.
-
-## Using our template
+We also have a longer [tutorial](./tutorial.md) that has been presented in workshops for researchers at UCL.
 
 If you have [uv] installed, you can use our template with the following one-liner:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Python packages with our recommended tooling set up and ready to go.
 > package template (e.g., [`scikit-hep`](https://github.com/scikit-hep/cookie)),
 > we recommend using their template instead of this one.
 
-
 ## Using our Python package template
 
 Some quick instructions for using our template are below.


### PR DESCRIPTION
These headings serve the same purpose (pointing users towards instructions for the template), so merge them into one