### PR TITLE
Fix some scikit-hep references

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Python packages with our recommended tooling set up and ready to go.
 
 > [!NOTE]
 > If you're making a package within a community that has an existing
-> package template (e.g., [`scikit-hep`](https://github.com/scikit-hep/cookie)),
+> package template (e.g., [`SciKit-Surgery`](https://github.com/SciKit-Surgery/PythonTemplate)),
 > we recommend using their template instead of this one.
 
 ## Using our Python package template

--- a/docs/pages/templates.md
+++ b/docs/pages/templates.md
@@ -29,7 +29,7 @@ their package template.
 | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Napari](https://github.com/napari/cookiecutter-napari-plugin)     | Cookiecutter template for authoring (npe2-based) napari plugins.                                                                                |
 | [SciKit-Surgery](https://github.com/SciKit-Surgery/PythonTemplate) | Cookiecutter template developed by the Wellcome EPSRC Centre for Interventional and Surgical Sciences.                                          |
-| [Scientific Python](https://github.com/scientific-python/cookie)   | Cookiecutter template developed by [SciKit-HEP](https://github.com/scikit-hep) but now adopted by the more general Scientific Python community. |
+| [Scientific Python](https://github.com/scientific-python/cookie)   | Cookiecutter template developed by [Scikit-HEP](https://github.com/scikit-hep) but now adopted by the more general Scientific Python community. |
 
 ### Template engines
 


### PR DESCRIPTION
XRef #558 

- SciKit-HEP -> Scikit-HEP
- Refer to SciKit-Surgery/PythonTemplate and not Scikit-HEP/cookie (redirects to Scientific-Python's cookie now)