### PR TITLE
Fix #559: Add license headers to test files

### DIFF
--- a/add_license.py
+++ b/add_license.py
@@ -1,0 +1,37 @@
+import os
+
+LICENSE = '''# Copyright 2024 University College London
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+
+FILES = [
+    "./tests/test_package_generation.py",
+    "./tests/test_git_init.py",
+    "./tests/data/test_package_generation/tests/test_dummy.py",
+    "./{{cookiecutter.project_slug}}/tests/test_dummy.py",
+]
+
+for filepath in FILES:
+    if os.path.exists(filepath):
+        with open(filepath, "r") as f:
+            content = f.read()
+        if "University College London" not in content:
+            with open(filepath, "w") as f:
+                f.write(LICENSE + content)
+            print(f"✅ Added license to {filepath}")
+        else:
+            print(f"ℹ️ License already exists in {filepath}")
+    else:
+        print(f"❌ File not found: {filepath}")

--- a/add_license.py
+++ b/add_license.py
@@ -1,6 +1,6 @@
 import os
 
-LICENSE = '''# Copyright 2024 University College London
+LICENSE = """# Copyright 2024 University College London
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ LICENSE = '''# Copyright 2024 University College London
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-'''
+"""
 
 FILES = [
     "./tests/test_package_generation.py",
@@ -25,7 +25,7 @@ FILES = [
 
 for filepath in FILES:
     if os.path.exists(filepath):
-        with open(filepath, "r") as f:
+        with open(filepath) as f:
             content = f.read()
         if "University College London" not in content:
             with open(filepath, "w") as f:

--- a/tests/data/test_package_generation/tests/test_dummy.py
+++ b/tests/data/test_package_generation/tests/test_dummy.py
@@ -1,3 +1,17 @@
+# Copyright 2024 University College London
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """An example set of tests."""
 
 

--- a/tests/test_git_init.py
+++ b/tests/test_git_init.py
@@ -1,3 +1,17 @@
+# Copyright 2024 University College London
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Checks that the git repo initialisation works."""
 
 import pathlib

--- a/tests/test_package_generation.py
+++ b/tests/test_package_generation.py
@@ -1,5 +1,19 @@
 """Checks that the cookiecutter works."""
 
+LICENSE = '''# Copyright 2024 University College London
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import difflib
 import os
 import pathlib

--- a/{{cookiecutter.project_slug}}/tests/test_dummy.py
+++ b/{{cookiecutter.project_slug}}/tests/test_dummy.py
@@ -1,3 +1,17 @@
+# Copyright 2024 University College London
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """An example set of tests."""
 
 


### PR DESCRIPTION
This PR addresses [Issue #559](https://github.com/UCL-ARC/python-tooling/issues/559) by adding the required Apache 2.0 license header to all relevant test files in the repository.

Files Updated:
tests/test_package_generation.py

tests/test_git_init.py

tests/data/test_package_generation/tests/test_dummy.py

{{cookiecutter.project_slug}}/tests/test_dummy.py

License Header Added:
# Copyright 2024 University College London
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.
All headers were inserted at the top of the file, above any imports, and existing headers were preserved if already present.