### PR TITLE
Switch to `dependency-groups`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cd example-research-software-project
 git init
 # uv venv
 # source .venv/bin/activate
-uv pip install -e . --group dev
+uv sync
 ```
 
 Note that `uv>=0.6.7` is required to use the `--group` option.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ git init
 uv pip install -e . --group dev
 ```
 
+Note that `uv>=0.6.7` is required to use the `--group` option.
+
 <!-- links here -->
 
 <!-- prettier-ignore-start -->

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cd example-research-software-project
 git init
 # uv venv
 # source .venv/bin/activate
-uv pip install -e ".[dev]"
+uv pip install -e . --group dev
 ```
 
 <!-- links here -->

--- a/tests/data/test_package_generation/pyproject.toml
+++ b/tests/data/test_package_generation/pyproject.toml
@@ -5,6 +5,27 @@ requires = [
     "setuptools-scm",
 ]
 
+[dependency-groups]
+dev = [
+    "build",
+    "mypy",
+    "pre-commit",
+    "ruff",
+    "tox",
+    "twine",
+]
+docs = [
+    "mkdocs",
+    "mkdocs-include-markdown-plugin",
+    "mkdocs-material",
+    "mkdocstrings",
+    "mkdocstrings-python",
+]
+test = [
+    "pytest",
+    "pytest-cov",
+]
+
 [project]
 authors = [
     {email = "eva.lu.ator@ucl.ac.uk", name = "Eva Lu Ator"},
@@ -31,23 +52,6 @@ license-files = [
     "LICENSE.md",
 ]
 name = "cookiecutter-test"
-optional-dependencies = {dev = [
-    "build",
-    "mypy",
-    "pre-commit",
-    "ruff",
-    "tox",
-    "twine",
-], docs = [
-    "mkdocs",
-    "mkdocs-include-markdown-plugin",
-    "mkdocs-material",
-    "mkdocstrings",
-    "mkdocstrings-python",
-], test = [
-    "pytest",
-    "pytest-cov",
-]}
 readme = "README.md"
 requires-python = ">=3.11"
 urls.homepage = "https://github.com/test-user/cookiecutter-test"
@@ -126,7 +130,7 @@ env_run_base = {commands = [
         "--cov",
         "--cov-report=xml",
     ],
-], extras = [
+], dependency_groups = [
     "test",
 ]}
 env.docs = {commands = [
@@ -135,7 +139,7 @@ env.docs = {commands = [
         "build",
         "--strict",
     ],
-], extras = [
+], dependency_groups = [
     "docs",
 ]}
 gh.python."3.11" = ["py311"]

--- a/tutorial.md
+++ b/tutorial.md
@@ -309,7 +309,7 @@ uv venv --python 3.11.6
 Once you have created and activated a virtual environment for the project, you can install the package in [editable mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html), along with both its required dependencies and optional sets of dependencies for development (`dev`), documentation (`docs`) and testing (`test`) by running
 
 ```sh
-uv pip install --editable ".[dev,docs,test]"
+uv pip install --editable . --group dev --group docs --group test
 ```
 
 from the root of the project repository.
@@ -343,7 +343,7 @@ python -m pip install --upgrade pip
 Similar to `uv`, once the environment is active, you can install the package in editable mode as well as all dependencies:
 
 ```sh
-python -m pip install --editable ".[dev,docs,test]"
+python -m pip install --editable . --group dev --group docs --group test
 ```
 
 </details>

--- a/tutorial.md
+++ b/tutorial.md
@@ -309,7 +309,7 @@ uv venv --python 3.11.6
 Once you have created and activated a virtual environment for the project, you can install the package in [editable mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html), along with both its required dependencies and optional sets of dependencies for development (`dev`), documentation (`docs`) and testing (`test`) by running
 
 ```sh
-uv pip install --editable . --group dev --group docs --group test
+uv sync --all-groups
 ```
 
 from the root of the project repository. Note that `uv>=0.6.7` is required to use the `--group` option.

--- a/tutorial.md
+++ b/tutorial.md
@@ -312,7 +312,7 @@ Once you have created and activated a virtual environment for the project, you c
 uv pip install --editable . --group dev --group docs --group test
 ```
 
-from the root of the project repository.
+from the root of the project repository. Note that `uv>=0.6.7` is required to use the `--group` option.
 
 <details><summary>Using venv as an alternative to uv </summary> <!-- markdownlint-disable-line MD033 -->
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -346,6 +346,8 @@ Similar to `uv`, once the environment is active, you can install the package in 
 python -m pip install --editable . --group dev --group docs --group test
 ```
 
+Note that `pip>=25.1` is required to use the `--group` option.
+
 </details>
 
 ## 🧪 Running package tests locally

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -5,6 +5,27 @@ requires = [
     "setuptools-scm",
 ]
 
+[dependency-groups]
+dev = [
+    "build",
+    "mypy",
+    "pre-commit",
+    "ruff",
+    "tox",
+    "twine",
+]
+docs = [
+    "mkdocs",
+    "mkdocs-include-markdown-plugin",
+    "mkdocs-material",
+    "mkdocstrings",
+    "mkdocstrings-python",
+]
+test = [
+    "pytest",
+    "pytest-cov",
+]
+
 [project]
 authors = [
     {email = "{{cookiecutter.author_email}}", name = "{{cookiecutter.author_given_names}} {{cookiecutter.author_family_names}}"},
@@ -34,23 +55,6 @@ license-files = [
     "LICENSE.md",
 ]
 name = "{{cookiecutter.project_slug}}"
-optional-dependencies = {dev = [
-    "build",
-    "mypy",
-    "pre-commit",
-    "ruff",
-    "tox",
-    "twine",
-], docs = [
-    "mkdocs",
-    "mkdocs-include-markdown-plugin",
-    "mkdocs-material",
-    "mkdocstrings",
-    "mkdocstrings-python",
-], test = [
-    "pytest",
-    "pytest-cov",
-]}
 readme = "README.md"
 requires-python = ">={{cookiecutter.min_python_version}}"
 urls.homepage = "{{cookiecutter.__repo_url}}"
@@ -132,7 +136,7 @@ env_run_base = {commands = [
         "--cov",
         "--cov-report=xml",
     ],
-], extras = [
+], dependency_groups = [
     "test",
 ]}
 env.docs = {commands = [
@@ -141,7 +145,7 @@ env.docs = {commands = [
         "build",
         "--strict",
     ],
-], extras = [
+], dependency_groups = [
     "docs",
 ]}
 {%- for python_version in range(


### PR DESCRIPTION
Fixes #570. Move to the modern `[dependency-groups]` syntax for non-user facing additional dependencies. See [PEP 735](https://peps.python.org/pep-0735/).