### PR TITLE
Fix the year and add a schedule to run the tests on Jan 2nd each year.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
       - main
       - "renovate/**"
   pull_request:
+  schedule:
+      - cron: "0 0 15 * *" # Run at 00:00 on the 15th of every month.
 
 jobs:
   test-template:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
       - "renovate/**"
   pull_request:
   schedule:
-    - cron: "0 0 15 * *" # Run at 00:00 on the 15th of every month.
+    - cron: "0 11 2 1 *" # Run at 11 am on the 2nd January
 
 jobs:
   test-template:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
       - "renovate/**"
   pull_request:
   schedule:
-      - cron: "0 0 15 * *" # Run at 00:00 on the 15th of every month.
+    - cron: "0 0 15 * *" # Run at 00:00 on the 15th of every month.
 
 jobs:
   test-template:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
     # Run at 11 am on the 2nd January each year to make sure
     # dates in package regression test data get updated
     # See https://github.com/UCL-ARC/python-tooling/pull/597
-    - cron: "0 11 2 1 *" 
+    - cron: "0 11 2 1 *"
 
 jobs:
   test-template:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,10 @@ on:
       - "renovate/**"
   pull_request:
   schedule:
-    - cron: "0 11 2 1 *" # Run at 11 am on the 2nd January
+    # Run at 11 am on the 2nd January each year to make sure
+    # dates in package regression test data get updated
+    # See https://github.com/UCL-ARC/python-tooling/pull/597
+    - cron: "0 11 2 1 *" 
 
 jobs:
   test-template:

--- a/tests/data/test_package_generation/LICENSE.md
+++ b/tests/data/test_package_generation/LICENSE.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable MD041 --># MIT License
 
-Copyright (c) 2025 Eva Lu Ator
+Copyright (c) 2026 Eva Lu Ator
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/tests/data/test_package_generation/mkdocs.yml
+++ b/tests/data/test_package_generation/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: "Cookiecutter Test"
 site_description: "Documentation website for Cookiecutter Test"
 site_author: "Eva Lu Ator"
-copyright: "Copyright © 2025 Eva Lu Ator"
+copyright: "Copyright © 2026 Eva Lu Ator"
 repo_url: "https://github.com/test-user/cookiecutter-test/"
 repo_name: "test-user/cookiecutter-test"
 edit_uri: edit/main/docs/


### PR DESCRIPTION
Regression tests are dumb. And years change.

I'd love it if we could find a way not to have the full-output regression test.

Failing that, I'm proposing a `cron` so that we at least get an email on the 2nd January, which reminds us to fix the year. I acknowledge that it's a dumb solution, but it's a dumb problem: so fairs fair.