### PR TITLE
Add link to presentations repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Python packages with our recommended tooling set up and ready to go.
 
 Some quick instructions for using our template are below.
 We also have a longer [tutorial](./tutorial.md) that has been presented in workshops for researchers at UCL.
+Slides from presentations we have given on the project are available in the
+[`python-tooling-presentations` repository](https://github.com/ucl-arc/python-tooling-presentations).
 
 If you have [uv] installed, you can use our template with the following command:
 


### PR DESCRIPTION
Resolves #576 

Adds a link and some pointer text to presentations repository in main README. Not sure if this section is best place for it as most users probably don't care that much about presentations so a bit of a distraction but equally as we already mention workshops in previous sentence seemed a natural lead on.